### PR TITLE
feat: replace file-based key with keycard auth flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,37 @@ When `keycard-basecamp` exposes Ed25519 key derivation:
 
 ---
 
+## Issue #12 — Add `source` field to `cid_pin` payload
+
+**Goal:** Let subscribers (Cord, future modules) know which Basecamp module a CID originated from.
+
+**Change:** Add a `source` field to the `cid_pin` inscription payload:
+
+```json
+{"v":1, "type":"cid_pin", "cid":"baf...", "label":"...", "source":"logos_notes", "ts":1234567890}
+```
+
+**Where `source` comes from:**
+- Stash calls `pinCid(cid, label)` — extend to `pinCid(cid, label, source)`
+- `source` is the calling module name, e.g. `"logos_notes"`, `"stash"`, `"logos_keycard"`
+- Default to `""` if not provided (backward compatible)
+
+**C++ change:** `pinCid(cid, label, source = "")` — store `source` in the log entry and include it in the payload passed back to QML.
+
+**QML change:** include `source` in the JSON payload constructed in `inscribeCid()`:
+```javascript
+var payload = JSON.stringify({
+    v: 1, type: "cid_pin", cid: cid, label: label,
+    source: source || "", ts: Math.floor(Date.now() / 1000)
+})
+```
+
+**Cord benefit:** `dispatchMessage` can filter/route by `payload.source` — e.g. "show me only Notes backups from Alice's channel".
+
+**Blocked on:** Stash passing `source` when calling `pinCid`. Stash currently calls `pinCid(cid, label)` — needs a third argument once this is implemented.
+
+---
+
 ## Common Pitfalls (from stash/keycard lessons)
 
 - **`background: null` on TextEdit** — silent QML load failure. Only valid on TextField/TextArea.
@@ -199,3 +230,4 @@ beacon-basecamp/
 | 9 | UI | Inscription log panel | done |
 | 10 | Tests | Unit tests | done |
 | 11 | UI | Real-time log update on inscription confirm | pending |
+| 12 | Core | Add `source` field to `cid_pin` payload | pending |

--- a/docs/retro-log.md
+++ b/docs/retro-log.md
@@ -150,3 +150,6 @@ Notes → Stash → Beacon (LEZ inscription). Zone-seq init required `set_channe
 
 ## fail 2026-04-24
 Senty 403 on GitHub comment: beacon-basecamp PR #2 review could not be posted automatically (Resource not accessible by integration). Findings were returned inline instead.
+
+## fail 2026-04-24
+Senty 403 repeated on beacon-basecamp PR #2 round 2 comment. GitHub integration token lacks write access to xAlisher/beacon-basecamp. Findings delivered inline again.

--- a/docs/retro-log.md
+++ b/docs/retro-log.md
@@ -147,3 +147,6 @@ Notes → Stash → Beacon (LEZ inscription). Zone-seq init required `set_channe
 - configureZoneSeq() slow load: defer blocking zone_seq calls out of Component.onCompleted
 - Issue #11: Real-time log update on inscription confirm — implemented via direct logModel.setProperty in QML (signal bridge approach abandoned)
 - Issue #12 (logos-notes): Show beacon inscription events in notes activity log — when a note backup is inscribed, notes should append an activity entry: "beacon backup {name} with CID {cid} successfully inscribed to {channel} on LEZ, status: Confirmed". Requires beacon to either emit a cross-module event or notes to poll beacon's getInscriptionLog(). — currently the log row goes straight from absent → confirmed (pending state never shown in UI). Options: (a) append a pending row to logModel immediately in QML before calling publish, then update in-place on confirm; (b) emit a C++ `inscriptionConfirmed(int entryIndex, QString inscriptionId, QString status)` signal that QML listens to for targeted row updates without full refresh. Option (b) is cleaner — avoids full re-read on every inscription and allows showing the pending→ok transition live.
+
+## fail 2026-04-24
+Senty 403 on GitHub comment: beacon-basecamp PR #2 review could not be posted automatically (Resource not accessible by integration). Findings were returned inline instead.

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -67,6 +67,7 @@ Item {
     // when the card is present. keycardAuthPollTimer polls checkAuthStatus until done.
     function requestKeycardAuth() {
         if (typeof logos === "undefined" || !logos.callModule) return
+        logos.callModule("logos_beacon", "clearSigningKey", [])
         root.keycardConnected  = false
         root.keycardAuthStatus = ""
         var raw = logos.callModule("keycard", "requestAuth", ["bc:beacon", "logos_beacon"])
@@ -338,12 +339,20 @@ Item {
             if (r.status === "complete") {
                 stop()
                 root.keycardAuthStatus = "complete"
-                root.keycardConnected  = true
-                // Deliver key to beacon C++ (for getBeaconConfig / getStatus)
-                logos.callModule("logos_beacon", "setSigningKey", [r.key])
+                // Deliver key to beacon C++ — only mark connected if key accepted
+                var skRaw = logos.callModule("logos_beacon", "setSigningKey", [r.key])
+                var skResult = root.callModuleParse(skRaw)
+                if (!skResult || skResult.error) {
+                    // Key rejected by backend (malformed); retry after delay
+                    root.keycardAuthStatus = "error"
+                    reconnectTimer.start()
+                    return
+                }
                 root.signingKeyHex = r.key
-                // Now configure zone sequencer with the card-bound key
+                // Configure zone sequencer — keycardConnected set only if ready
                 root.configureZoneSeq()
+                if (root.zoneSeqReady)
+                    root.keycardConnected = true
             } else if (r.status === "rejected" || r.status === "failed") {
                 stop()
                 root.keycardAuthStatus  = r.status
@@ -379,6 +388,8 @@ Item {
             var raw = logos.callModule("keycard", "getState", [])
             var r = root.callModuleParse(raw)
             if (!r || r.state !== "SESSION_ACTIVE") {
+                // Clear backend signing key before any re-request
+                logos.callModule("logos_beacon", "clearSigningKey", [])
                 root.keycardConnected  = false
                 root.keycardAuthStatus = ""
                 root.keycardAuthId     = ""

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -37,6 +37,7 @@ Item {
     // ── Keycard auth state ────────────────────────────────────────────────────
     property string keycardAuthId:      ""   // set after requestAuth succeeds
     property string keycardAuthStatus:  ""   // "" | "pending" | "complete" | "rejected" | "error"
+    property bool   keycardConnected:   false // true only after auth complete + key delivered
 
     // ── Hidden clipboard helper ───────────────────────────────────────────────
     TextEdit {
@@ -66,6 +67,8 @@ Item {
     // when the card is present. keycardAuthPollTimer polls checkAuthStatus until done.
     function requestKeycardAuth() {
         if (typeof logos === "undefined" || !logos.callModule) return
+        root.keycardConnected  = false
+        root.keycardAuthStatus = ""
         var raw = logos.callModule("keycard", "requestAuth", ["bc:beacon", "logos_beacon"])
         var r = callModuleParse(raw)
         if (r && r.authId) {
@@ -74,6 +77,7 @@ Item {
             keycardAuthPollTimer.start()
         } else {
             root.keycardAuthStatus = "error"
+            reconnectTimer.start()
         }
     }
 
@@ -225,6 +229,7 @@ Item {
     function pollStash() {
         if (root.pollBusy) return
         if (!root.watchStash) return
+        if (!root.keycardConnected) return
         if (typeof logos === "undefined" || !logos.callModule) return
 
         root.pollBusy = true
@@ -305,7 +310,7 @@ Item {
     Timer {
         id: stashPollTimer
         interval: 10000
-        running:  root.watchStash
+        running:  root.watchStash && root.keycardConnected
         repeat:   true
         onTriggered: root.pollStash()
     }
@@ -333,6 +338,7 @@ Item {
             if (r.status === "complete") {
                 stop()
                 root.keycardAuthStatus = "complete"
+                root.keycardConnected  = true
                 // Deliver key to beacon C++ (for getBeaconConfig / getStatus)
                 logos.callModule("logos_beacon", "setSigningKey", [r.key])
                 root.signingKeyHex = r.key
@@ -340,7 +346,46 @@ Item {
                 root.configureZoneSeq()
             } else if (r.status === "rejected" || r.status === "failed") {
                 stop()
-                root.keycardAuthStatus = r.status
+                root.keycardAuthStatus  = r.status
+                root.keycardConnected   = false
+                reconnectTimer.start()
+            }
+        }
+    }
+
+    // ── Reconnect after auth rejection / keycard not available ───────────────
+    // Single-shot: fires once after a rejection or requestAuth error, then
+    // re-queues a fresh auth request so the user can try again without reloading.
+    Timer {
+        id: reconnectTimer
+        interval: 10000
+        running:  false
+        repeat:   false
+        onTriggered: root.requestKeycardAuth()
+    }
+
+    // ── Card removal detection ────────────────────────────────────────────────
+    // While connected, polls keycard.getState() every 8s. If the card is no
+    // longer present (state != SESSION_ACTIVE), resets keycardConnected and
+    // re-queues a fresh auth request so Beacon resumes as soon as the card
+    // is reinserted and re-approved.
+    Timer {
+        id: cardCheckTimer
+        interval: 8000
+        running:  root.keycardConnected
+        repeat:   true
+        onTriggered: {
+            if (typeof logos === "undefined" || !logos.callModule) return
+            var raw = logos.callModule("keycard", "getState", [])
+            var r = root.callModuleParse(raw)
+            if (!r || r.state !== "SESSION_ACTIVE") {
+                root.keycardConnected  = false
+                root.keycardAuthStatus = ""
+                root.keycardAuthId     = ""
+                root.signingKeyHex     = ""
+                root.zoneSeqReady      = false
+                root.channelId         = ""
+                root.requestKeycardAuth()
             }
         }
     }

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -338,7 +338,6 @@ Item {
             if (!r) return
             if (r.status === "complete") {
                 stop()
-                root.keycardAuthStatus = "complete"
                 // Deliver key to beacon C++ — only mark connected if key accepted
                 var skRaw = logos.callModule("logos_beacon", "setSigningKey", [r.key])
                 var skResult = root.callModuleParse(skRaw)
@@ -349,10 +348,17 @@ Item {
                     return
                 }
                 root.signingKeyHex = r.key
-                // Configure zone sequencer — keycardConnected set only if ready
+                // Configure zone sequencer
                 root.configureZoneSeq()
-                if (root.zoneSeqReady)
-                    root.keycardConnected = true
+                if (root.zoneSeqReady) {
+                    // Full success — auth complete and sequencer ready
+                    root.keycardAuthStatus = "complete"
+                    root.keycardConnected  = true
+                } else {
+                    // Key accepted but sequencer failed — surface error and retry
+                    root.keycardAuthStatus = "error"
+                    reconnectTimer.start()
+                }
             } else if (r.status === "rejected" || r.status === "failed") {
                 stop()
                 root.keycardAuthStatus  = r.status

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -31,6 +31,12 @@ Item {
     property int  stashSeenCount: 0
     property bool pollBusy:       false
     property int  inscribedCount: 0
+    property string channelLabel:       "My Beacon"
+    property string broadcastStatus:    ""   // "" | "ok" | "error"
+
+    // ── Keycard auth state ────────────────────────────────────────────────────
+    property string keycardAuthId:      ""   // set after requestAuth succeeds
+    property string keycardAuthStatus:  ""   // "" | "pending" | "complete" | "rejected" | "error"
 
     // ── Hidden clipboard helper ───────────────────────────────────────────────
     TextEdit {
@@ -53,6 +59,22 @@ Item {
             }
             return tmp
         } catch(e) { return null }
+    }
+
+    // ── Keycard auth request ──────────────────────────────────────────────────
+    // Queues a requestAuth for domain "bc:beacon". The keycard UI will surface it
+    // when the card is present. keycardAuthPollTimer polls checkAuthStatus until done.
+    function requestKeycardAuth() {
+        if (typeof logos === "undefined" || !logos.callModule) return
+        var raw = logos.callModule("keycard", "requestAuth", ["bc:beacon", "logos_beacon"])
+        var r = callModuleParse(raw)
+        if (r && r.authId) {
+            root.keycardAuthId     = r.authId
+            root.keycardAuthStatus = "pending"
+            keycardAuthPollTimer.start()
+        } else {
+            root.keycardAuthStatus = "error"
+        }
     }
 
     // ── Zone sequencer setup (called once at startup) ─────────────────────────
@@ -160,6 +182,40 @@ Item {
         root.pollBusy = false
     }
 
+    // ── Broadcast channel announce ────────────────────────────────────────────
+    function broadcastChannel() {
+        if (root.pollBusy) return
+        if (!root.zoneSeqReady || root.channelId === "") return
+        root.pollBusy = true
+        root.broadcastStatus = ""
+
+        // Save current label first
+        logos.callModule("logos_beacon", "setChannelLabel", [root.channelLabel])
+
+        var payload = JSON.stringify({
+            v:          1,
+            type:       "channel_announce",
+            module:     "logos_beacon",
+            channel_id: root.channelId,
+            label:      root.channelLabel,
+            ts:         Math.floor(Date.now() / 1000)
+        })
+
+        var pubRaw    = logos.callModule("liblogos_zone_sequencer_module",
+                                         "publish", [payload])
+        var pubResult = callModuleParse(pubRaw)
+
+        var isError = false
+        if (typeof pubResult === 'string') {
+            isError = pubResult.toLowerCase().startsWith("error") || pubResult.length === 0
+        } else if (pubResult && pubResult.error) {
+            isError = true
+        }
+
+        root.broadcastStatus = isError ? "error" : "ok"
+        root.pollBusy = false
+    }
+
     // ── Stash log polling ─────────────────────────────────────────────────────
     function extractCid(text) {
         var m = text.match(/\b(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-zA-Z0-9]{50,})\b/)
@@ -231,14 +287,17 @@ Item {
         var cfg    = callModuleParse(cfgRaw)
         if (!cfg) return
 
-        root.signingKeyHex   = cfg.signingKeyHex  || ""
         root.nodeUrl         = cfg.nodeUrl         || "http://127.0.0.1:8080"
         root.watchStash      = cfg.watchStash !== false
         root.persistencePath = cfg.persistencePath || ""
+        root.channelLabel    = cfg.channelLabel    || "My Beacon"
 
-        nodeUrlInput.text = root.nodeUrl
+        nodeUrlInput.text       = root.nodeUrl
+        channelLabelInput.text  = root.channelLabel
 
-        configureZoneSeq()
+        // Key now comes from keycard — request auth on startup.
+        // configureZoneSeq() is called once auth completes (keycardAuthPollTimer).
+        requestKeycardAuth()
         refreshLog()
     }
 
@@ -256,6 +315,34 @@ Item {
         running:  true
         repeat:   true
         onTriggered: root.refreshLog()
+    }
+
+    // ── Keycard auth poll ─────────────────────────────────────────────────────
+    // Polls checkAuthStatus until the user approves (or rejects) on the keycard UI.
+    // On completion: delivers key to logos_beacon and configures zone sequencer.
+    Timer {
+        id: keycardAuthPollTimer
+        interval: 750
+        running: false
+        repeat: true
+        onTriggered: {
+            if (root.keycardAuthId === "") { stop(); return }
+            var raw = logos.callModule("keycard", "checkAuthStatus", [root.keycardAuthId])
+            var r = root.callModuleParse(raw)
+            if (!r) return
+            if (r.status === "complete") {
+                stop()
+                root.keycardAuthStatus = "complete"
+                // Deliver key to beacon C++ (for getBeaconConfig / getStatus)
+                logos.callModule("logos_beacon", "setSigningKey", [r.key])
+                root.signingKeyHex = r.key
+                // Now configure zone sequencer with the card-bound key
+                root.configureZoneSeq()
+            } else if (r.status === "rejected" || r.status === "failed") {
+                stop()
+                root.keycardAuthStatus = r.status
+            }
+        }
     }
 
     // ── Log model ─────────────────────────────────────────────────────────────
@@ -294,6 +381,28 @@ Item {
                     text: root.inscribedCount + " inscribed"
                     color: root.textSecondary
                     font.pixelSize: 12
+                }
+            }
+
+            // ── Keycard auth status banner ────────────────────────────────────
+            Rectangle {
+                visible: root.keycardAuthStatus !== "complete"
+                Layout.fillWidth: true
+                height: 30
+                radius: 4
+                color: root.keycardAuthStatus === "rejected" || root.keycardAuthStatus === "error"
+                       ? "#2A1515" : "#1A1A2A"
+                Layout.topMargin: 4
+
+                Text {
+                    anchors.centerIn: parent
+                    text: root.keycardAuthStatus === ""        ? "Requesting Keycard auth..." :
+                          root.keycardAuthStatus === "pending"  ? "Waiting for Keycard approval — open Keycard tab" :
+                          root.keycardAuthStatus === "rejected" ? "Keycard auth rejected — reload to retry" :
+                          root.keycardAuthStatus === "error"    ? "Keycard not available — key not loaded" : ""
+                    color: root.keycardAuthStatus === "rejected" || root.keycardAuthStatus === "error"
+                           ? root.errorRed : root.textSecondary
+                    font.pixelSize: 11
                 }
             }
 
@@ -421,6 +530,94 @@ Item {
                                     onClicked: root.copyToClipboard(root.channelId)
                                 }
                             }
+                        }
+                    }
+
+                    // Channel label + Broadcast row
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 4
+
+                        Text {
+                            text: "Channel Label"
+                            color: root.textSecondary
+                            font.pixelSize: 11
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            Rectangle {
+                                Layout.fillWidth: true
+                                height: 32
+                                color: root.bgSecondary
+                                radius: 4
+                                border.color: channelLabelInput.activeFocus
+                                              ? root.accent : root.borderColor
+                                border.width: 1
+
+                                Behavior on border.color { ColorAnimation { duration: 100 } }
+
+                                TextField {
+                                    id: channelLabelInput
+                                    anchors.fill: parent
+                                    anchors.margins: 1
+                                    color: root.textPrimary
+                                    font.pixelSize: 12
+                                    background: null
+                                    leftPadding: 8
+                                    placeholderText: "My Beacon"
+                                    placeholderTextColor: root.textMuted
+                                    text: root.channelLabel
+                                    onTextChanged: root.channelLabel = text
+                                }
+                            }
+
+                            Rectangle {
+                                width: 100; height: 32
+                                radius: 4
+                                color: broadcastArea.pressed      ? root.accentPressed
+                                     : broadcastArea.containsMouse ? root.accentHover
+                                     : (root.zoneSeqReady && root.channelId !== "")
+                                       ? root.accent : "#555555"
+                                opacity: (root.zoneSeqReady && root.channelId !== "") ? 1.0 : 0.6
+
+                                Behavior on color { ColorAnimation { duration: 100 } }
+
+                                Text {
+                                    anchors.centerIn: parent
+                                    text: "Broadcast"
+                                    color: "#FFFFFF"
+                                    font.pixelSize: 12
+                                    font.bold: true
+                                }
+
+                                MouseArea {
+                                    id: broadcastArea
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    enabled: root.zoneSeqReady && root.channelId !== ""
+                                    onClicked: root.broadcastChannel()
+                                }
+
+                                ToolTip.visible: broadcastArea.containsMouse
+                                ToolTip.text: root.zoneSeqReady && root.channelId !== ""
+                                    ? "Inscribe channel_announce to your Beacon channel"
+                                    : "Zone sequencer not ready"
+                            }
+                        }
+
+                        // Broadcast result feedback
+                        Text {
+                            visible: root.broadcastStatus !== ""
+                            text: root.broadcastStatus === "ok"
+                                ? "✓ Channel announced on-chain"
+                                : "✗ Broadcast failed — check zone sequencer"
+                            color: root.broadcastStatus === "ok"
+                                ? root.successGreen : root.errorRed
+                            font.pixelSize: 11
+                            Layout.fillWidth: true
                         }
                     }
 

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -7,12 +7,11 @@
 #include <QDateTime>
 #include <QFile>
 #include <QDir>
-#include <QRandomGenerator>
-#include <QFileDevice>
 
 // ── QSettings key prefix ──────────────────────────────────────────────────────
-static constexpr const char* kNodeUrlKey   = "beacon/nodeUrl";
-static constexpr const char* kWatchStashKey = "beacon/watchStash";
+static constexpr const char* kNodeUrlKey      = "beacon/nodeUrl";
+static constexpr const char* kWatchStashKey   = "beacon/watchStash";
+static constexpr const char* kChannelLabelKey = "beacon/channelLabel";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 QString BeaconPlugin::errorJson(const QString& msg)
@@ -51,39 +50,19 @@ void BeaconPlugin::initLogos(LogosAPI* api)
 
     QDir().mkpath(m_persistencePath);
 
-    ensureKey();
     loadLog();
 }
 
-// ── ensureKey ─────────────────────────────────────────────────────────────────
-// Generate a fresh Ed25519 seed (32 bytes) on first run; read it back on
-// subsequent runs. Stored as 64-char lowercase hex, chmod 0600.
-void BeaconPlugin::ensureKey()
+// ── setSigningKey ─────────────────────────────────────────────────────────────
+// Called from QML after keycardAuthComplete delivers the 32-byte domain key.
+// Replaces the old file-based ensureKey() — key now comes from hardware each session.
+QString BeaconPlugin::setSigningKey(const QString& hexKey)
 {
-    if (m_persistencePath.isEmpty())
-        return;
+    if (hexKey.length() != 64 || QByteArray::fromHex(hexKey.toUtf8()).size() != 32)
+        return errorJson(QStringLiteral("hexKey must be 64 hex chars (32 bytes)"));
 
-    QString keyPath = m_persistencePath + QStringLiteral("/beacon.key");
-
-    if (!QFile::exists(keyPath)) {
-        // 8 × uint32 = 32 bytes of cryptographically secure randomness
-        QByteArray seed(32, Qt::Uninitialized);
-        QRandomGenerator::system()->fillRange(
-            reinterpret_cast<quint32*>(seed.data()), 8);
-
-        QFile f(keyPath);
-        if (f.open(QIODevice::WriteOnly)) {
-            f.write(seed.toHex());
-            f.close();
-            f.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner);
-        }
-    }
-
-    QFile f(keyPath);
-    if (f.open(QIODevice::ReadOnly)) {
-        m_signingKeyHex = QString::fromLatin1(f.readAll().trimmed());
-        f.close();
-    }
+    m_signingKeyHex = hexKey;
+    return okJson();
 }
 
 // ── getBeaconConfig ───────────────────────────────────────────────────────────
@@ -96,6 +75,8 @@ QString BeaconPlugin::getBeaconConfig() const
                                                     QStringLiteral("http://127.0.0.1:8080")).toString();
     o[QStringLiteral("watchStash")]      = s.value(QLatin1String(kWatchStashKey), true).toBool();
     o[QStringLiteral("persistencePath")] = m_persistencePath;
+    o[QStringLiteral("channelLabel")]    = s.value(QLatin1String(kChannelLabelKey),
+                                                    QStringLiteral("My Beacon")).toString();
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
@@ -114,6 +95,14 @@ QString BeaconPlugin::setWatchStash(bool enabled)
 {
     QSettings s;
     s.setValue(QLatin1String(kWatchStashKey), enabled);
+    return okJson();
+}
+
+// ── setChannelLabel ───────────────────────────────────────────────────────────
+QString BeaconPlugin::setChannelLabel(const QString& label)
+{
+    QSettings s;
+    s.setValue(QLatin1String(kChannelLabelKey), label.trimmed());
     return okJson();
 }
 

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -65,6 +65,14 @@ QString BeaconPlugin::setSigningKey(const QString& hexKey)
     return okJson();
 }
 
+// ── clearSigningKey ───────────────────────────────────────────────────────────
+// Called from QML on card removal or auth restart.
+QString BeaconPlugin::clearSigningKey()
+{
+    m_signingKeyHex.clear();
+    return okJson();
+}
+
 // ── getBeaconConfig ───────────────────────────────────────────────────────────
 QString BeaconPlugin::getBeaconConfig() const
 {

--- a/src/plugin/BeaconPlugin.h
+++ b/src/plugin/BeaconPlugin.h
@@ -56,6 +56,10 @@ public:
     // Returns {"ok":true} or {"error":"..."}
     Q_INVOKABLE QString setSigningKey(const QString& hexKey);
 
+    // Called from QML on card removal or auth restart — clears m_signingKeyHex.
+    // Returns {"ok":true}
+    Q_INVOKABLE QString clearSigningKey();
+
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
     void inscriptionConfirmed(int entryIndex, const QString& inscriptionId,

--- a/src/plugin/BeaconPlugin.h
+++ b/src/plugin/BeaconPlugin.h
@@ -22,7 +22,7 @@ public:
     Q_INVOKABLE void initLogos(LogosAPI* api);
 
     // ── Config ───────────────────────────────────────────────────────────────
-    // Returns {signingKeyHex, nodeUrl, watchStash:bool, persistencePath}
+    // Returns {signingKeyHex, nodeUrl, watchStash:bool, persistencePath, channelLabel}
     Q_INVOKABLE QString getBeaconConfig() const;
 
     // Persists beacon/nodeUrl. Returns {"ok":true} or {"error":"..."}
@@ -30,6 +30,9 @@ public:
 
     // Persists beacon/watchStash. Returns {"ok":true}
     Q_INVOKABLE QString setWatchStash(bool enabled);
+
+    // Persists beacon/channelLabel. Returns {"ok":true}
+    Q_INVOKABLE QString setChannelLabel(const QString& label);
 
     // ── State ────────────────────────────────────────────────────────────────
     // Returns {configured:bool, seenCids:N, inscribedCids:N}
@@ -49,13 +52,16 @@ public:
                                            const QString& inscriptionId,
                                            const QString& status);
 
+    // Called from QML after keycardAuthComplete — sets m_signingKeyHex (32-byte hex).
+    // Returns {"ok":true} or {"error":"..."}
+    Q_INVOKABLE QString setSigningKey(const QString& hexKey);
+
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
     void inscriptionConfirmed(int entryIndex, const QString& inscriptionId,
                               const QString& status);
 
 private:
-    void     ensureKey();
     void     loadLog();
     void     saveLog();
 

--- a/tests/test_beacon_plugin.cpp
+++ b/tests/test_beacon_plugin.cpp
@@ -84,6 +84,32 @@ private slots:
         // Key must remain empty after failed attempts
         auto cfg = parseObj(p.getBeaconConfig());
         QVERIFY(cfg["signingKeyHex"].toString().isEmpty());
+
+        // getStatus must report configured=false (guard stays closed)
+        auto st = parseObj(p.getStatus());
+        QCOMPARE(st["configured"].toBool(), false);
+    }
+
+    void testClearSigningKey()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        // Set a valid key
+        p.setSigningKey("a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1");
+        QVERIFY(parseObj(p.getStatus())["configured"].toBool());
+
+        // Clear (card removal / auth restart)
+        auto r = parseObj(p.clearSigningKey());
+        QVERIFY(r["ok"].toBool());
+
+        // Backend state reset: key empty, configured=false
+        QVERIFY(parseObj(p.getBeaconConfig())["signingKeyHex"].toString().isEmpty());
+        QCOMPARE(parseObj(p.getStatus())["configured"].toBool(), false);
     }
 
     // ── Config tests ──────────────────────────────────────────────────────────

--- a/tests/test_beacon_plugin.cpp
+++ b/tests/test_beacon_plugin.cpp
@@ -36,9 +36,10 @@ private:
     }
 
 private slots:
-    // ── Key generation tests ──────────────────────────────────────────────────
+    // ── setSigningKey tests ───────────────────────────────────────────────────
+    // Key now comes from Keycard hardware each session — no file generated.
 
-    void testEnsureKeyCreatesFile()
+    void testSetSigningKeyValid()
     {
         QTemporaryDir tmp;
         QVERIFY(tmp.isValid());
@@ -47,53 +48,42 @@ private slots:
         p.setProperty("instancePersistencePath", tmp.path());
         p.initLogos(nullptr);
 
-        QString keyPath = tmp.path() + "/beacon.key";
-        QVERIFY(QFile::exists(keyPath));
+        // Before setSigningKey: key is empty, beacon.key file not created
+        auto cfg0 = parseObj(p.getBeaconConfig());
+        QVERIFY(cfg0["signingKeyHex"].toString().isEmpty());
+        QVERIFY(!QFile::exists(tmp.path() + "/beacon.key"));
 
-        QFile f(keyPath);
-        QVERIFY(f.open(QIODevice::ReadOnly));
-        QByteArray content = f.readAll().trimmed();
-        f.close();
+        // Set a valid 32-byte key (64 hex chars)
+        const QString key =
+            "a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1";
+        auto r = parseObj(p.setSigningKey(key));
+        QVERIFY(!r.contains("error"));
+        QVERIFY(r["ok"].toBool());
 
-        // 64-char hex
-        QCOMPARE(content.length(), 64);
-        // All hex chars
-        QRegularExpression hexRe("^[0-9a-f]{64}$");
-        QVERIFY(hexRe.match(QString::fromLatin1(content)).hasMatch());
-
-        // Mode 0600
-        QFileDevice::Permissions perms = QFile::permissions(keyPath);
-        QVERIFY(perms & QFileDevice::ReadOwner);
-        QVERIFY(perms & QFileDevice::WriteOwner);
-        QVERIFY(!(perms & QFileDevice::ReadGroup));
-        QVERIFY(!(perms & QFileDevice::WriteGroup));
-        QVERIFY(!(perms & QFileDevice::ReadOther));
-        QVERIFY(!(perms & QFileDevice::WriteOther));
+        auto cfg = parseObj(p.getBeaconConfig());
+        QCOMPARE(cfg["signingKeyHex"].toString(), key);
     }
 
-    void testEnsureKeyIdempotent()
+    void testSetSigningKeyInvalid()
     {
         QTemporaryDir tmp;
         QVERIFY(tmp.isValid());
 
-        BeaconPlugin p1;
-        p1.setProperty("instancePersistencePath", tmp.path());
-        p1.initLogos(nullptr);
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
 
-        auto cfg1 = parseObj(p1.getBeaconConfig());
-        QString key1 = cfg1["signingKeyHex"].toString();
+        // Too short
+        auto r1 = parseObj(p.setSigningKey("abc123"));
+        QVERIFY(r1.contains("error"));
 
-        // Second plugin instance, same path
-        BeaconPlugin p2;
-        p2.setProperty("instancePersistencePath", tmp.path());
-        p2.initLogos(nullptr);
+        // 64 chars but non-hex → fromHex returns partial/empty → size != 32
+        auto r2 = parseObj(p.setSigningKey(QString(64, 'z')));
+        QVERIFY(r2.contains("error"));
 
-        auto cfg2 = parseObj(p2.getBeaconConfig());
-        QString key2 = cfg2["signingKeyHex"].toString();
-
-        // Same key — not regenerated
-        QCOMPARE(key1, key2);
-        QVERIFY(!key1.isEmpty());
+        // Key must remain empty after failed attempts
+        auto cfg = parseObj(p.getBeaconConfig());
+        QVERIFY(cfg["signingKeyHex"].toString().isEmpty());
     }
 
     // ── Config tests ──────────────────────────────────────────────────────────
@@ -113,7 +103,8 @@ private slots:
 
         auto cfg = parseObj(p.getBeaconConfig());
         QVERIFY(cfg.contains("signingKeyHex"));
-        QVERIFY(cfg["signingKeyHex"].toString().length() == 64);
+        // Key is empty on init — delivered by Keycard hardware at runtime
+        QVERIFY(cfg["signingKeyHex"].toString().isEmpty());
         QCOMPARE(cfg["nodeUrl"].toString(), QString("http://127.0.0.1:8080"));
         QCOMPARE(cfg["watchStash"].toBool(), true);
         QCOMPARE(cfg["persistencePath"].toString(), tmp.path());
@@ -251,6 +242,56 @@ private slots:
         QVERIFY(r.contains("error"));
     }
 
+    // ── Channel label tests ───────────────────────────────────────────────────
+
+    void testSetChannelLabelPersists()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+
+        QSettings s;
+        s.remove("beacon");
+
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto r = parseObj(p.setChannelLabel("Alice's Notes"));
+        QVERIFY(r["ok"].toBool());
+
+        auto cfg = parseObj(p.getBeaconConfig());
+        QCOMPARE(cfg["channelLabel"].toString(), QString("Alice's Notes"));
+    }
+
+    void testGetBeaconConfigDefaultLabel()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+
+        QSettings s;
+        s.remove("beacon");
+
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto cfg = parseObj(p.getBeaconConfig());
+        QCOMPARE(cfg["channelLabel"].toString(), QString("My Beacon"));
+    }
+
+    void testSetChannelLabelTrimmed()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        p.setChannelLabel("  trimmed  ");
+        auto cfg = parseObj(p.getBeaconConfig());
+        QCOMPARE(cfg["channelLabel"].toString(), QString("trimmed"));
+    }
+
     void testGetStatusCounts()
     {
         QTemporaryDir tmp;
@@ -267,10 +308,16 @@ private slots:
         p.confirmInscription(pin1["entryIndex"].toInt(), "id1", "ok");
         p.confirmInscription(pin2["entryIndex"].toInt(), "",    "error");
 
+        // Without a signing key, configured = false
+        auto st0 = parseObj(p.getStatus());
+        QCOMPARE(st0["configured"].toBool(), false);
+        QCOMPARE(st0["seenCids"].toInt(), 2);
+        QCOMPARE(st0["inscribedCids"].toInt(), 1);
+
+        // After key delivered by Keycard, configured = true
+        p.setSigningKey("a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1c2d3e4f5a0b1");
         auto st = parseObj(p.getStatus());
         QCOMPARE(st["configured"].toBool(), true);
-        QCOMPARE(st["seenCids"].toInt(), 2);
-        QCOMPARE(st["inscribedCids"].toInt(), 1);
     }
 };
 


### PR DESCRIPTION
## Summary

- Remove `ensureKey()` / `beacon.key` file — signing key now comes from hardware (Keycard) each session
- Add `setSigningKey(hexKey)` Q_INVOKABLE — called from QML after auth completes
- QML requests auth on startup: `requestAuth("bc:beacon", "logos_beacon")`
- Polls `checkAuthStatus` every 750ms (Timer) until user approves on Keycard UI
- On complete: delivers key to C++ via `setSigningKey`, then calls `configureZoneSeq()`
- Status banner: "Waiting for Keycard approval — open Keycard tab"

## Auth flow

```
Beacon startup → requestAuth("bc:beacon", "logos_beacon") → keycardAuthId
Keycard UI shows request → user enters PIN
keycardAuthPollTimer fires → checkAuthStatus(authId) → status:"complete", key:hex
→ setSigningKey(key) → configureZoneSeq() → zone seq live
```

## Test plan

- [ ] Start Basecamp with Keycard tab open, card paired → Beacon requests auth → approve → Beacon status banner disappears, zone seq goes green
- [ ] Start Beacon tab first — banner shows "Waiting for Keycard approval" → switch to Keycard → approve → Beacon activates
- [ ] Reject auth → banner shows "rejected"
- [ ] Verify `beacon.key` file no longer created on first run

Implements Part 4 of plan signed off by @bitgamma in [keycard-basecamp#148](https://github.com/xAlisher/keycard-basecamp/issues/148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)