### PR TITLE
fix: findExplorerTxHash — use explorer block API for real tx hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # ── Qt ────────────────────────────────────────────────────────────────────────
 list(PREPEND CMAKE_PREFIX_PATH "$ENV{HOME}/Qt/6.9.3/gcc_64")
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Network)
 qt_standard_project_setup()
 
 # ── Nix store paths ───────────────────────────────────────────────────────────
@@ -72,6 +72,7 @@ target_include_directories(logos_beacon_plugin PRIVATE
 target_link_libraries(logos_beacon_plugin PRIVATE
     Qt6::Core
     Qt6::Qml
+    Qt6::Network
     "${LOGOS_CPP_SDK}/lib/liblogos_sdk.a"
     dl pthread
 )
@@ -105,6 +106,7 @@ target_include_directories(test_beacon_plugin PRIVATE
 target_link_libraries(test_beacon_plugin PRIVATE
     Qt6::Core
     Qt6::Test
+    Qt6::Network
     dl pthread
 )
 

--- a/docs/retro-log.md
+++ b/docs/retro-log.md
@@ -189,6 +189,14 @@ success; re-derive guard `!manifestedModules[source]` keeps it idempotent. Extra
 
 QML calling `pinCid(cid, label, source)` (3 args) against installed .so that only registered 2-arg `pinCid(cid, label)`. Qt bridge silently rejected the call. Symptom: `callModuleParse` returned null → logged "error: pinCid Invalid response". Fix: rebuild + reinstall .so. Root cause: issue #12 was implemented in source but the installed .so was never updated in the previous session.
 
+## win 2026-05-26 — beacon#11 fix: module sub-channel routing + instant explorer URLs
+
+PR fix/11-module-channel-publish merged. Two-part fix:
+1. zone_sequencer single-handle guard blocked multi-channel publishing. Added `publish_to()` to zone-sequencer-module with `QMap<QString, void*> m_channelHandles` cache — each module sub-channel gets its own persistent handle, returns `mantle_tx.hash` directly.
+2. Option A (anchor polling) replaced with persistent handle approach — resolved "awaiting on-chain anchor..." indefinite wait that was too slow for demo. Explorer URLs now appear within seconds of inscription.
+Skills extracted: `zone-publish-hash-type-mismatch` (critical), `zone-seq-multi-channel-publish-to` (high).
+Added `clearInscriptionLog()` C++ invokable + "Clear" buttons inline with Log and Activity headers.
+
 ## win 2026-05-21
 fix: beacon aligned with logos-module-builder b3f1d658 + RC3 SDK
 

--- a/docs/retro-log.md
+++ b/docs/retro-log.md
@@ -188,3 +188,8 @@ success; re-derive guard `!manifestedModules[source]` keeps it idempotent. Extra
 ## fail 2026-04-30 — pinCid "Invalid response" from installed .so with 2-arg signature
 
 QML calling `pinCid(cid, label, source)` (3 args) against installed .so that only registered 2-arg `pinCid(cid, label)`. Qt bridge silently rejected the call. Symptom: `callModuleParse` returned null → logged "error: pinCid Invalid response". Fix: rebuild + reinstall .so. Root cause: issue #12 was implemented in source but the installed .so was never updated in the previous session.
+
+## win 2026-05-21
+fix: beacon aligned with logos-module-builder b3f1d658 + RC3 SDK
+
+nixpkgs.follows required `...` in outputs destructuring (was erroring "unexpected argument 'nixpkgs'"). CMakeLists.txt hardcoded Nix store paths (logos-cpp-sdk + liblogos-headers) go stale after module-builder update — updated to new hashes. logos_api_stub.cpp: added logos_object.h include; dropped onEvent stub (BeaconPlugin doesn't use it, avoids SDK signature drift). 25/25 unit tests pass on Qt 6.9.3. Verified live — modules load, inscription flow works.

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -37,6 +37,11 @@ Item {
     property string channelLabel:      "My Beacon"   // kept for future use
     property string broadcastStatus:   ""             // kept for future use
 
+    // ── Inscription lifecycle state ───────────────────────────────────────────
+    property int  currentLibSlot:      0
+    property var  pendingFinalizations: []
+    property bool finalizationBusy:    false
+
     // ── Screen state ──────────────────────────────────────────────────────────
     property string currentScreen: "landing"   // "landing" | "main"
 
@@ -117,7 +122,7 @@ Item {
         logos.callModule("liblogos_zone_sequencer_module", "set_node_url",
                          [root.nodeUrl])
         logos.callModule("liblogos_zone_sequencer_module", "set_checkpoint_path",
-                         [root.persistencePath + "/beacon.checkpoint"])
+                         [""])  // empty = bootstrap fresh, no stale-checkpoint backfill
 
         var chRaw = logos.callModule("liblogos_zone_sequencer_module",
                                      "get_channel_id", [])
@@ -148,7 +153,7 @@ Item {
         // temporary signing-key switch in setupModuleChannel doesn't leave stale state
         logos.callModule("liblogos_zone_sequencer_module", "set_signing_key", [root.signingKeyHex])
         logos.callModule("liblogos_zone_sequencer_module", "set_checkpoint_path",
-                         [root.persistencePath + "/beacon.checkpoint"])
+                         [""])  // empty = no stale-checkpoint backfill
         logos.callModule("liblogos_zone_sequencer_module", "set_channel_id", [""])
         var chRaw2 = logos.callModule("liblogos_zone_sequencer_module", "get_channel_id", [])
         var ch2 = callModuleParse(chRaw2)
@@ -223,27 +228,36 @@ Item {
         if (root.pollBusy) return
         root.pollBusy = true
 
-        var useKey, useChannelId, useCheckpoint
+        // Capture node slot / lib_slot for slotFrom, libAtSubmit, and progress tracking
+        var nodeSlot = 0
+        var libSlot  = 0
+        var infoRaw = logos.callModule("logos_beacon", "getNodeInfo", [])
+        var info = callModuleParse(infoRaw)
+        if (info && info.slot) {
+            nodeSlot = info.slot
+            libSlot  = info.lib_slot || 0
+            root.currentLibSlot = libSlot
+        }
+
+        var useKey, useChannelId
         if (source && source.length > 0) {
             setupModuleChannel(source)
             var mc = root.moduleChannels[source]
             if (mc) {
-                useKey        = mc.signingKey
-                useChannelId  = mc.channelId
-                useCheckpoint = root.persistencePath + "/checkpoints/" + source + ".checkpoint"
+                useKey       = mc.signingKey
+                useChannelId = mc.channelId
             } else {
                 appendActivity("using primary channel for " + source, "info")
-                useKey        = root.signingKeyHex
-                useChannelId  = root.channelId
-                useCheckpoint = root.persistencePath + "/beacon.checkpoint"
+                useKey       = root.signingKeyHex
+                useChannelId = root.channelId
             }
         } else {
-            useKey        = root.signingKeyHex
-            useChannelId  = root.channelId
-            useCheckpoint = root.persistencePath + "/beacon.checkpoint"
+            useKey       = root.signingKeyHex
+            useChannelId = root.channelId
         }
 
-        var pinRaw = logos.callModule("logos_beacon", "pinCid", [cid, label, source || ""])
+        var pinRaw = logos.callModule("logos_beacon", "pinCid",
+                                      [cid, label, source || "", nodeSlot, libSlot])
         var pin    = callModuleParse(pinRaw)
 
         if (!pin || pin.error) {
@@ -264,7 +278,9 @@ Item {
             source:        source || "",
             tsStr:         Qt.formatDateTime(now, "HH:mm:ss"),
             inscriptionId: "",
-            status:        "pending"
+            status:        "queued",
+            slotFrom:      nodeSlot,
+            libAtSubmit:   libSlot
         })
 
         var payload = JSON.stringify({
@@ -278,18 +294,14 @@ Item {
 
         var pubRaw
         if (useChannelId === root.channelId) {
-            // Primary beacon channel — use the persistent sequencer handle (fast path)
+            // Primary beacon channel — persistent sequencer handle
             pubRaw = logos.callModule("liblogos_zone_sequencer_module", "publish", [payload])
         } else {
-            // Module sub-channel — publish_to uses a cached persistent handle per channel,
-            // so it returns mantle_tx.hash directly (same as publish() on the primary channel).
+            // Module sub-channel — pass empty checkpoint (no stale-checkpoint backfill)
             pubRaw = logos.callModule("liblogos_zone_sequencer_module",
-                                      "publish_to", [useChannelId, useKey, useCheckpoint, payload])
+                                      "publish_to", [useChannelId, useKey, "", payload])
         }
         var pubResult = callModuleParse(pubRaw)
-
-        var inscriptionId = ""
-        var status        = "error"
 
         var isError = false
         if (typeof pubResult === 'string') {
@@ -298,40 +310,41 @@ Item {
             isError = true
         }
 
-        if (!isError) {
-            if (typeof pubResult === 'string') {
-                inscriptionId = pubResult
-                status        = "ok"
-            } else if (pubResult && pubResult.inscriptionId) {
-                inscriptionId = pubResult.inscriptionId
-                status        = "ok"
-            } else if (pubResult && pubResult.id) {
-                inscriptionId = pubResult.id
-                status        = "ok"
-            }
-        }
-
-        // Both publish() and publish_to() return mantle_tx.hash — confirm immediately.
-        logos.callModule("logos_beacon", "confirmInscription",
-                         [entryIndex, inscriptionId, status])
-        if (entryIndex >= 0 && entryIndex < logModel.count) {
-            logModel.setProperty(entryIndex, "inscriptionId", inscriptionId)
-            logModel.setProperty(entryIndex, "status", status)
-            if (status === "ok") root.inscribedCount++
-        }
-
-        if (status !== "ok")
+        if (isError) {
+            logos.callModule("logos_beacon", "confirmInscription", [entryIndex, "", "failed"])
+            if (entryIndex >= 0 && entryIndex < logModel.count)
+                logModel.setProperty(entryIndex, "status", "failed")
             appendActivity("[" + (source || "primary") + "] inscription error — " + cid.substring(0,16) + "…", "error")
+            root.pollBusy = false
+            return false
+        }
+
+        // Submitted — deferred confirmation via finalizationTimer (block scan → real explorer hash)
+        logos.callModule("logos_beacon", "confirmInscription", [entryIndex, "", "submitted"])
+        if (entryIndex >= 0 && entryIndex < logModel.count)
+            logModel.setProperty(entryIndex, "status", "submitted")
+
+        var updatedPF = root.pendingFinalizations.slice()
+        updatedPF.push({
+            entryIndex:  entryIndex,
+            channelId:   useChannelId,
+            slotFrom:    nodeSlot,
+            libAtSubmit: libSlot,
+            cid:         cid
+        })
+        root.pendingFinalizations = updatedPF
+
+        appendActivity("[" + (source || "primary") + "] submitted — " + cid.substring(0,16) + "… awaiting finalization", "info")
 
         // Manifest module channel to primary Beacon channel on first successful inscription
-        if (status === "ok" && source && source.length > 0
+        if (source && source.length > 0
                 && root.moduleChannels[source]
                 && !root.manifestedModules[source]) {
             inscribeManifest(source, root.moduleChannels[source].channelId)
         }
 
         root.pollBusy = false
-        return status === "ok"
+        return true
     }
 
     // ── Broadcast channel announce (kept for future use; not exposed in UI) ───
@@ -417,9 +430,11 @@ Item {
                 source:        e.source || "",
                 tsStr:         Qt.formatDateTime(ts, "HH:mm:ss"),
                 inscriptionId: e.inscriptionId || "",
-                status:        e.status || "pending"
+                status:        e.status || "pending",
+                slotFrom:      e.slotFrom    || 0,
+                libAtSubmit:   e.libAtSubmit || 0
             })
-            if (e.status === "ok") count++
+            if (e.status === "ok" || e.status === "confirmed") count++
         }
         root.inscribedCount = count
     }
@@ -474,6 +489,10 @@ Item {
         nodeUrlInput.text = root.nodeUrl
 
         refreshLog()
+
+        var niRaw = logos.callModule("logos_beacon", "getNodeInfo", [])
+        var ni = callModuleParse(niRaw)
+        if (ni && ni.lib_slot) root.currentLibSlot = ni.lib_slot
     }
 
     // ── Timers ────────────────────────────────────────────────────────────────
@@ -494,6 +513,89 @@ Item {
         onTriggered: {
             root.refreshLog()
             root.refreshModules()
+            // Keep currentLibSlot fresh for in-flight progress bars
+            var niRaw = logos.callModule("logos_beacon", "getNodeInfo", [])
+            var ni = root.callModuleParse(niRaw)
+            if (ni && ni.lib_slot) root.currentLibSlot = ni.lib_slot
+        }
+    }
+
+    // ── Finalization poll — scans blocks for real explorer TX hash ────────────
+    Timer {
+        id: finalizationTimer
+        interval: 6000
+        running:  true
+        repeat:   true
+        onTriggered: {
+            if (root.pendingFinalizations.length === 0) return
+            if (root.finalizationBusy) return
+            if (typeof logos === "undefined" || !logos.callModule) return
+            root.finalizationBusy = true
+
+            var niRaw2 = logos.callModule("logos_beacon", "getNodeInfo", [])
+            var ni2 = root.callModuleParse(niRaw2)
+            if (ni2 && ni2.lib_slot) root.currentLibSlot = ni2.lib_slot
+            var libNow = root.currentLibSlot
+
+            var remaining = []
+            var pf = root.pendingFinalizations
+            for (var i = 0; i < pf.length; i++) {
+                var item = pf[i]
+
+                // Need lib_slot to have advanced past slotFrom for the tx to be finalized
+                if (libNow <= item.slotFrom) {
+                    // Update to "finalizing" once node slot has passed slotFrom
+                    if (libNow > 0 && item.slotFrom > 0
+                            && item.entryIndex >= 0 && item.entryIndex < logModel.count) {
+                        var curSt = logModel.get(item.entryIndex).status
+                        if (curSt === "submitted" || curSt === "queued") {
+                            logModel.setProperty(item.entryIndex, "status", "finalizing")
+                            logos.callModule("logos_beacon", "confirmInscription",
+                                            [item.entryIndex, "", "finalizing"])
+                        }
+                    }
+                    remaining.push(item)
+                    continue
+                }
+
+                var slotTo = libNow
+                var fRaw = logos.callModule("logos_beacon", "findExplorerTxHash",
+                                            [item.channelId, item.slotFrom, slotTo])
+                var fResult = root.callModuleParse(fRaw)
+
+                if (fResult && fResult.found === true
+                        && fResult.txHash && fResult.txHash.length > 0) {
+                    // Confirmed — store real explorer hash
+                    logos.callModule("logos_beacon", "confirmInscription",
+                                    [item.entryIndex, fResult.txHash, "confirmed"])
+                    if (item.entryIndex >= 0 && item.entryIndex < logModel.count) {
+                        logModel.setProperty(item.entryIndex, "inscriptionId", fResult.txHash)
+                        logModel.setProperty(item.entryIndex, "status", "confirmed")
+                    }
+                    root.inscribedCount++
+                    appendActivity("confirmed: " + item.cid.substring(0, 16) + "…  " + fResult.txHash.substring(0, 16) + "…", "success")
+                } else if (slotTo > item.slotFrom + 3000) {
+                    // Timed out — ~50 min of trying without success
+                    logos.callModule("logos_beacon", "confirmInscription",
+                                    [item.entryIndex, "", "failed"])
+                    if (item.entryIndex >= 0 && item.entryIndex < logModel.count)
+                        logModel.setProperty(item.entryIndex, "status", "failed")
+                    appendActivity("failed (timeout): " + item.cid.substring(0, 16) + "…", "error")
+                } else {
+                    // Still scanning — mark finalizing if not already
+                    if (item.entryIndex >= 0 && item.entryIndex < logModel.count) {
+                        var st2 = logModel.get(item.entryIndex).status
+                        if (st2 !== "finalizing") {
+                            logModel.setProperty(item.entryIndex, "status", "finalizing")
+                            logos.callModule("logos_beacon", "confirmInscription",
+                                            [item.entryIndex, "", "finalizing"])
+                        }
+                    }
+                    remaining.push(item)
+                }
+            }
+            root.pendingFinalizations = remaining
+            root.finalizationBusy = false
         }
     }
 
@@ -572,6 +674,7 @@ Item {
         keycardAuthPollTimer.stop()
         cardCheckTimer.stop()
         stashPollTimer.stop()
+        finalizationTimer.stop()
     }
 
     // ── Models ────────────────────────────────────────────────────────────────
@@ -1183,36 +1286,165 @@ Item {
                             spacing: 2
                             onCountChanged: Qt.callLater(() => logListView.positionViewAtEnd())
 
-                            delegate: TextEdit {
+                            delegate: Item {
+                                id: logEntry
+                                required property int    index
                                 required property string cid
                                 required property string label
                                 required property string source
                                 required property string tsStr
                                 required property string inscriptionId
                                 required property string status
+                                required property int    slotFrom
+                                required property int    libAtSubmit
 
                                 width: logListView.width
-                                text: {
-                                    var fname = label
-                                    if (label.indexOf("Logos Storage: ") === 0) {
-                                        var parts = label.split(" → ")
-                                        fname = parts[0].replace("Logos Storage: ", "")
-                                    }
-                                    var chain = (source && source !== "primary")
-                                        ? "[" + source + " → stash → Logos Storage]"
-                                        : "[primary]"
-                                    return "[" + tsStr + "] Inscribed " + (cid.length > 0 ? cid.substring(0, 12) : "unknown") + "… for " + fname + " " + chain
+                                implicitHeight: entryCol.implicitHeight + 10
+
+                                // Progress: lib advancing from libAtSubmit toward slotFrom
+                                property real progressVal: {
+                                    if (status === "confirmed" || status === "ok") return 1.0
+                                    if (status === "failed" || status === "error") return 0.0
+                                    if (slotFrom <= 0 || libAtSubmit <= 0) return 0.0
+                                    var total = slotFrom - libAtSubmit
+                                    if (total <= 0) return 0.0
+                                    var elapsed = root.currentLibSlot - libAtSubmit
+                                    return Math.min(1.0, Math.max(0.0, elapsed / total))
                                 }
-                                color: status === "ok"    ? root.successGreen
-                                     : status === "error" ? root.errorRed
-                                     : root.warningYellow
-                                font.pixelSize: 11
-                                font.family: "Courier New, monospace"
-                                wrapMode: Text.WrapAnywhere
-                                readOnly: true
-                                selectByMouse: true
-                                selectedTextColor: root.bgPrimary
-                                selectionColor: root.textSecondary
+
+                                // Remaining slots → ~M:SS estimate
+                                property string timeEst: {
+                                    if (status === "confirmed" || status === "ok"
+                                            || status === "failed" || status === "error") return ""
+                                    if (slotFrom <= 0 || root.currentLibSlot <= 0) return ""
+                                    var rem = slotFrom - root.currentLibSlot
+                                    if (rem <= 0) return ""
+                                    var mins = Math.floor(rem / 60)
+                                    var secs = rem % 60
+                                    return "~" + mins + ":" + (secs < 10 ? "0" : "") + secs
+                                }
+
+                                property string explorerUrl:
+                                    inscriptionId.length > 0
+                                    ? "https://testnet.blockchain.logos.co/web/explorer/transactions/" + inscriptionId
+                                    : ""
+
+                                property bool inFlight: status === "queued"
+                                                     || status === "submitted"
+                                                     || status === "finalizing"
+                                property bool isDone:   status === "confirmed" || status === "ok"
+                                property bool isFailed: status === "failed" || status === "error"
+
+                                ColumnLayout {
+                                    id: entryCol
+                                    anchors { left: parent.left; right: parent.right
+                                              top: parent.top; topMargin: 4 }
+                                    spacing: 3
+
+                                    // Line 1: [time] label   source
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 6
+
+                                        Text {
+                                            text: "[" + tsStr + "] " + (label.length > 0 ? label : cid.substring(0, 20) + "…")
+                                            font.pixelSize: 11
+                                            font.family: "Courier New, monospace"
+                                            color: logEntry.isDone   ? root.successGreen
+                                                 : logEntry.isFailed ? root.errorRed
+                                                 : root.textPrimary
+                                            elide: Text.ElideRight
+                                            Layout.fillWidth: true
+                                        }
+
+                                        Text {
+                                            visible: source.length > 0
+                                            text: source
+                                            font.pixelSize: 9
+                                            color: root.textMuted
+                                        }
+                                    }
+
+                                    // Line 2: CID  +  progress bar / hash + copy URL / failed
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 6
+
+                                        Text {
+                                            text: cid.length > 0 ? cid.substring(0, 20) + "…" : "…"
+                                            font.pixelSize: 10
+                                            font.family: "Courier New, monospace"
+                                            color: root.textMuted
+                                        }
+
+                                        // Progress bar (in-flight only)
+                                        Rectangle {
+                                            visible: logEntry.inFlight
+                                            Layout.fillWidth: true
+                                            height: 4; radius: 2
+                                            color: root.bgSecondary
+
+                                            Rectangle {
+                                                width: parent.width * logEntry.progressVal
+                                                height: parent.height; radius: parent.radius
+                                                color: root.accentOrange
+                                                Behavior on width { NumberAnimation { duration: 600 } }
+                                            }
+                                        }
+
+                                        // Time estimate (in-flight, while we have an estimate)
+                                        Text {
+                                            visible: logEntry.inFlight && logEntry.timeEst.length > 0
+                                            text: logEntry.timeEst
+                                            font.pixelSize: 10
+                                            color: root.textMuted
+                                        }
+
+                                        // Truncated hash (confirmed)
+                                        Text {
+                                            visible: logEntry.isDone && inscriptionId.length > 0
+                                            text: inscriptionId.substring(0, 16) + "…"
+                                            font.pixelSize: 10
+                                            font.family: "Courier New, monospace"
+                                            color: root.successGreen
+                                        }
+
+                                        // Copy URL button (confirmed)
+                                        Rectangle {
+                                            visible: logEntry.isDone && logEntry.explorerUrl.length > 0
+                                            height: 18
+                                            implicitWidth: copyUrlLabel.implicitWidth + 14
+                                            radius: 3
+                                            color: copyUrlArea.pressed      ? root.accentPressed
+                                                 : copyUrlArea.containsMouse ? root.accentHover : root.bgSecondary
+                                            border.color: root.borderColor; border.width: 1
+                                            Behavior on color { ColorAnimation { duration: 80 } }
+
+                                            Text {
+                                                id: copyUrlLabel
+                                                anchors.centerIn: parent
+                                                text: "copy URL"
+                                                font.pixelSize: 9
+                                                color: root.textPrimary
+                                            }
+
+                                            MouseArea {
+                                                id: copyUrlArea
+                                                anchors.fill: parent
+                                                hoverEnabled: true; cursorShape: Qt.PointingHandCursor
+                                                onClicked: root.copyToClipboard(logEntry.explorerUrl)
+                                            }
+                                        }
+
+                                        // Failed label
+                                        Text {
+                                            visible: logEntry.isFailed
+                                            text: "failed"
+                                            font.pixelSize: 10
+                                            color: root.errorRed
+                                        }
+                                    }
+                                }
                             }
                         }
                     }

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -33,7 +33,6 @@ Item {
     property bool   pollBusy:          false
     property var    manifestedModules: ({})   // module name → true, loaded from manifest-log.json
     property int    inscribedCount:    0
-    property var    pendingResolutions: []
     property string channelLabel:      "My Beacon"   // kept for future use
     property string broadcastStatus:   ""             // kept for future use
 

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -33,8 +33,6 @@ Item {
     property bool   pollBusy:          false
     property var    manifestedModules: ({})   // module name → true, loaded from manifest-log.json
     property int    inscribedCount:    0
-    // Pending zone-message → mantle_tx.hash resolutions for module sub-channels.
-    // Each entry: {entryIndex, channelId, attempts}
     property var    pendingResolutions: []
     property string channelLabel:      "My Beacon"   // kept for future use
     property string broadcastStatus:   ""             // kept for future use
@@ -283,8 +281,8 @@ Item {
             // Primary beacon channel — use the persistent sequencer handle (fast path)
             pubRaw = logos.callModule("liblogos_zone_sequencer_module", "publish", [payload])
         } else {
-            // Module sub-channel — use stateless publish_to so the correct channel is used.
-            // publish() would silently go to the primary handle regardless of set_channel_id.
+            // Module sub-channel — publish_to uses a cached persistent handle per channel,
+            // so it returns mantle_tx.hash directly (same as publish() on the primary channel).
             pubRaw = logos.callModule("liblogos_zone_sequencer_module",
                                       "publish_to", [useChannelId, useKey, useCheckpoint, payload])
         }
@@ -313,25 +311,13 @@ Item {
             }
         }
 
-        var isModuleChannel = useChannelId !== root.channelId
-
-        if (!isModuleChannel || status !== "ok") {
-            // Primary channel or error: confirm immediately with whatever ID we have.
-            logos.callModule("logos_beacon", "confirmInscription",
-                             [entryIndex, inscriptionId, status])
-            if (entryIndex >= 0 && entryIndex < logModel.count) {
-                logModel.setProperty(entryIndex, "inscriptionId", inscriptionId)
-                logModel.setProperty(entryIndex, "status", status)
-                if (status === "ok") root.inscribedCount++
-            }
-        } else {
-            // Module sub-channel: zone_publish returns zone message hash, not mantle_tx.hash.
-            // Queue resolution — resolveAnchorTxs() will poll blocks until the real tx hash
-            // is found, then call confirmInscription with the correct ID.
-            var pending = root.pendingResolutions.slice()
-            pending.push({ entryIndex: entryIndex, channelId: useChannelId, attempts: 0 })
-            root.pendingResolutions = pending
-            appendActivity("[" + source + "] zone msg published — awaiting on-chain anchor…", "info")
+        // Both publish() and publish_to() return mantle_tx.hash — confirm immediately.
+        logos.callModule("logos_beacon", "confirmInscription",
+                         [entryIndex, inscriptionId, status])
+        if (entryIndex >= 0 && entryIndex < logModel.count) {
+            logModel.setProperty(entryIndex, "inscriptionId", inscriptionId)
+            logModel.setProperty(entryIndex, "status", status)
+            if (status === "ok") root.inscribedCount++
         }
 
         if (status !== "ok")
@@ -412,74 +398,6 @@ Item {
     }
 
     // ── Anchor tx resolution (module sub-channels) ────────────────────────────
-    // Polls /cryptarchia/blocks for the ChannelInscribe tx that anchors a module
-    // channel's zone messages on-chain, then updates the inscription log entry
-    // with the real mantle_tx.hash so the explorer URL works.
-    function resolveAnchorTxs() {
-        if (root.pendingResolutions.length === 0) return
-        if (typeof logos === "undefined" || !logos.callModule) return
-
-        var MAX_ATTEMPTS = 36  // 36 × 15s = 9 min before giving up
-        var SLOT_WINDOW  = 800 // search ≈800 slots (~13 min) back from current tip
-
-        var remaining = []
-        for (var i = 0; i < root.pendingResolutions.length; i++) {
-            var p = root.pendingResolutions[i]
-
-            // First confirm the zone message is finalized (visible in query_channel).
-            var qRaw = logos.callModule("liblogos_zone_sequencer_module",
-                                        "query_channel", [p.channelId, 1])
-            var msgs = callModuleParse(qRaw)
-            if (!Array.isArray(msgs) || msgs.length === 0) {
-                // Not yet finalized — check attempt count.
-                if (p.attempts < MAX_ATTEMPTS) {
-                    remaining.push({ entryIndex: p.entryIndex,
-                                     channelId:  p.channelId,
-                                     attempts:   p.attempts + 1 })
-                } else {
-                    appendActivity("anchor tx resolution timed out for entry " + p.entryIndex, "error")
-                }
-                continue
-            }
-
-            // Zone message is finalized. Now find the ChannelInscribe tx on-chain.
-            // Get current node tip slot to define search range.
-            var tipRaw = logos.callModule("liblogos_zone_sequencer_module",
-                                          "query_channel_paged", [p.channelId, "", 1])
-            var paged = callModuleParse(tipRaw)
-            var tipSlot = (paged && paged.cursor_slot) ? paged.cursor_slot : 0
-
-            var slotTo   = tipSlot > 0 ? tipSlot + 10 : 9999999
-            var slotFrom = slotTo - SLOT_WINDOW
-
-            var anchorRaw = logos.callModule("logos_beacon", "findAnchorTx",
-                                             [root.nodeUrl, p.channelId, slotFrom, slotTo])
-            var anchor = callModuleParse(anchorRaw)
-
-            if (anchor && anchor.txHash && anchor.txHash.length > 0) {
-                logos.callModule("logos_beacon", "confirmInscription",
-                                 [p.entryIndex, anchor.txHash, "ok"])
-                if (p.entryIndex >= 0 && p.entryIndex < logModel.count) {
-                    logModel.setProperty(p.entryIndex, "inscriptionId", anchor.txHash)
-                    logModel.setProperty(p.entryIndex, "status", "ok")
-                    root.inscribedCount++
-                }
-                appendActivity("anchor resolved: " + anchor.txHash.substring(0, 16) + "…", "success")
-            } else {
-                // Zone message visible but no anchor tx yet — keep retrying.
-                if (p.attempts < MAX_ATTEMPTS) {
-                    remaining.push({ entryIndex: p.entryIndex,
-                                     channelId:  p.channelId,
-                                     attempts:   p.attempts + 1 })
-                } else {
-                    appendActivity("anchor tx not found in blocks for entry " + p.entryIndex, "error")
-                }
-            }
-        }
-
-        root.pendingResolutions = remaining
-    }
-
     // ── Log refresh ───────────────────────────────────────────────────────────
     function refreshLog() {
         if (typeof logos === "undefined" || !logos.callModule) return
@@ -566,7 +484,6 @@ Item {
         repeat:   true
         onTriggered: {
             root.pollModules()
-            root.resolveAnchorTxs()
         }
     }
 
@@ -1221,6 +1138,23 @@ Item {
                                 }
                             }
                         }
+
+                        Text {
+                            text: "Clear"
+                            font.pixelSize: 11
+                            color: clearLogArea.containsMouse ? root.textSecondary : root.textMuted
+                            Behavior on color { ColorAnimation { duration: 120 } }
+                            MouseArea {
+                                id: clearLogArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: {
+                                    logos.callModule("logos_beacon", "clearInscriptionLog", [])
+                                    logModel.clear()
+                                }
+                            }
+                        }
                     }
 
                     Rectangle {
@@ -1319,6 +1253,20 @@ Item {
                                 }
                                 root.copyToClipboard(lines.join("\n"))
                             }
+                        }
+                    }
+
+                    Text {
+                        text: "Clear"
+                        font.pixelSize: 11
+                        color: clearActArea.containsMouse ? root.textSecondary : root.textMuted
+                        Behavior on color { ColorAnimation { duration: 120 } }
+                        MouseArea {
+                            id: clearActArea
+                            anchors.fill: parent
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: activityLogModel.clear()
                         }
                     }
                 }

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -631,6 +631,33 @@ Item {
                     appendActivity("zone sequencer ready — " + root.channelId.substring(0,16) + "…", "success")
                     root.currentScreen     = "main"
                     root.refreshModules()
+
+                    // Re-populate pendingFinalizations for any in-flight inscriptions
+                    // (handles beacon restart while inscriptions were in submitted/finalizing state)
+                    var restored = []
+                    for (var ri = 0; ri < logModel.count; ri++) {
+                        var le = logModel.get(ri)
+                        if ((le.status === "submitted" || le.status === "finalizing" || le.status === "queued")
+                                && le.slotFrom > 0) {
+                            var useChId = root.channelId
+                            if (le.source && le.source.length > 0) {
+                                setupModuleChannel(le.source)
+                                var rmc = root.moduleChannels[le.source]
+                                if (rmc) useChId = rmc.channelId
+                            }
+                            restored.push({
+                                entryIndex:  ri,
+                                channelId:   useChId,
+                                slotFrom:    le.slotFrom,
+                                libAtSubmit: le.libAtSubmit || 0,
+                                cid:         le.cid
+                            })
+                        }
+                    }
+                    if (restored.length > 0) {
+                        root.pendingFinalizations = restored
+                        appendActivity("resumed " + restored.length + " in-flight inscription(s)", "info")
+                    }
                 } else {
                     root.keycardAuthStatus = "error"
                 }

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -33,6 +33,9 @@ Item {
     property bool   pollBusy:          false
     property var    manifestedModules: ({})   // module name → true, loaded from manifest-log.json
     property int    inscribedCount:    0
+    // Pending zone-message → mantle_tx.hash resolutions for module sub-channels.
+    // Each entry: {entryIndex, channelId, attempts}
+    property var    pendingResolutions: []
     property string channelLabel:      "My Beacon"   // kept for future use
     property string broadcastStatus:   ""             // kept for future use
 
@@ -310,18 +313,28 @@ Item {
             }
         }
 
-        logos.callModule("logos_beacon", "confirmInscription",
-                         [entryIndex, inscriptionId, status])
+        var isModuleChannel = useChannelId !== root.channelId
 
-        if (entryIndex >= 0 && entryIndex < logModel.count) {
-            logModel.setProperty(entryIndex, "inscriptionId", inscriptionId)
-            logModel.setProperty(entryIndex, "status", status)
-            if (status === "ok") root.inscribedCount++
+        if (!isModuleChannel || status !== "ok") {
+            // Primary channel or error: confirm immediately with whatever ID we have.
+            logos.callModule("logos_beacon", "confirmInscription",
+                             [entryIndex, inscriptionId, status])
+            if (entryIndex >= 0 && entryIndex < logModel.count) {
+                logModel.setProperty(entryIndex, "inscriptionId", inscriptionId)
+                logModel.setProperty(entryIndex, "status", status)
+                if (status === "ok") root.inscribedCount++
+            }
+        } else {
+            // Module sub-channel: zone_publish returns zone message hash, not mantle_tx.hash.
+            // Queue resolution — resolveAnchorTxs() will poll blocks until the real tx hash
+            // is found, then call confirmInscription with the correct ID.
+            var pending = root.pendingResolutions.slice()
+            pending.push({ entryIndex: entryIndex, channelId: useChannelId, attempts: 0 })
+            root.pendingResolutions = pending
+            appendActivity("[" + source + "] zone msg published — awaiting on-chain anchor…", "info")
         }
 
-        if (status === "ok")
-            appendActivity("[" + (source || "primary") + "] inscribed " + cid.substring(0,16) + "…", "success")
-        else
+        if (status !== "ok")
             appendActivity("[" + (source || "primary") + "] inscription error — " + cid.substring(0,16) + "…", "error")
 
         // Manifest module channel to primary Beacon channel on first successful inscription
@@ -396,6 +409,75 @@ Item {
         }
 
         root.pollBusy = false
+    }
+
+    // ── Anchor tx resolution (module sub-channels) ────────────────────────────
+    // Polls /cryptarchia/blocks for the ChannelInscribe tx that anchors a module
+    // channel's zone messages on-chain, then updates the inscription log entry
+    // with the real mantle_tx.hash so the explorer URL works.
+    function resolveAnchorTxs() {
+        if (root.pendingResolutions.length === 0) return
+        if (typeof logos === "undefined" || !logos.callModule) return
+
+        var MAX_ATTEMPTS = 36  // 36 × 15s = 9 min before giving up
+        var SLOT_WINDOW  = 800 // search ≈800 slots (~13 min) back from current tip
+
+        var remaining = []
+        for (var i = 0; i < root.pendingResolutions.length; i++) {
+            var p = root.pendingResolutions[i]
+
+            // First confirm the zone message is finalized (visible in query_channel).
+            var qRaw = logos.callModule("liblogos_zone_sequencer_module",
+                                        "query_channel", [p.channelId, 1])
+            var msgs = callModuleParse(qRaw)
+            if (!Array.isArray(msgs) || msgs.length === 0) {
+                // Not yet finalized — check attempt count.
+                if (p.attempts < MAX_ATTEMPTS) {
+                    remaining.push({ entryIndex: p.entryIndex,
+                                     channelId:  p.channelId,
+                                     attempts:   p.attempts + 1 })
+                } else {
+                    appendActivity("anchor tx resolution timed out for entry " + p.entryIndex, "error")
+                }
+                continue
+            }
+
+            // Zone message is finalized. Now find the ChannelInscribe tx on-chain.
+            // Get current node tip slot to define search range.
+            var tipRaw = logos.callModule("liblogos_zone_sequencer_module",
+                                          "query_channel_paged", [p.channelId, "", 1])
+            var paged = callModuleParse(tipRaw)
+            var tipSlot = (paged && paged.cursor_slot) ? paged.cursor_slot : 0
+
+            var slotTo   = tipSlot > 0 ? tipSlot + 10 : 9999999
+            var slotFrom = slotTo - SLOT_WINDOW
+
+            var anchorRaw = logos.callModule("logos_beacon", "findAnchorTx",
+                                             [root.nodeUrl, p.channelId, slotFrom, slotTo])
+            var anchor = callModuleParse(anchorRaw)
+
+            if (anchor && anchor.txHash && anchor.txHash.length > 0) {
+                logos.callModule("logos_beacon", "confirmInscription",
+                                 [p.entryIndex, anchor.txHash, "ok"])
+                if (p.entryIndex >= 0 && p.entryIndex < logModel.count) {
+                    logModel.setProperty(p.entryIndex, "inscriptionId", anchor.txHash)
+                    logModel.setProperty(p.entryIndex, "status", "ok")
+                    root.inscribedCount++
+                }
+                appendActivity("anchor resolved: " + anchor.txHash.substring(0, 16) + "…", "success")
+            } else {
+                // Zone message visible but no anchor tx yet — keep retrying.
+                if (p.attempts < MAX_ATTEMPTS) {
+                    remaining.push({ entryIndex: p.entryIndex,
+                                     channelId:  p.channelId,
+                                     attempts:   p.attempts + 1 })
+                } else {
+                    appendActivity("anchor tx not found in blocks for entry " + p.entryIndex, "error")
+                }
+            }
+        }
+
+        root.pendingResolutions = remaining
     }
 
     // ── Log refresh ───────────────────────────────────────────────────────────
@@ -482,7 +564,10 @@ Item {
         interval: 10000
         running:  true   // always running; pollModules() checks keycardConnected internally
         repeat:   true
-        onTriggered: root.pollModules()
+        onTriggered: {
+            root.pollModules()
+            root.resolveAnchorTxs()
+        }
     }
 
     Timer {

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -30,7 +30,6 @@ Item {
     property bool   zoneSeqReady:      false
     property bool   settingsPanelOpen: false
 
-    property int    stashSeenCount:    0
     property bool   pollBusy:          false
     property var    manifestedModules: ({})   // module name → true, loaded from manifest-log.json
     property int    inscribedCount:    0
@@ -372,45 +371,33 @@ Item {
         root.pollBusy = false
     }
 
-    // ── Stash log polling ─────────────────────────────────────────────────────
-    function extractCid(text) {
-        var m = text.match(/\b(Qm[1-9A-HJ-NP-Za-km-z]{44}|baf[a-zA-Z0-9]{50,}|zDvZ[1-9A-HJ-NP-Za-km-z]{40,})\b/)
-        return m ? m[1] : ""
-    }
-
-    function pollStash() {
+    // ── Module inscription queue polling ─────────────────────────────────────
+    function pollModules() {
         if (root.pollBusy) return
         if (!root.keycardConnected) return
         if (typeof logos === "undefined" || !logos.callModule) return
+        if (root.watchedSources.length === 0) return
 
         root.pollBusy = true
 
-        var raw     = logos.callModule("stash", "getLog", [])
-        var entries = callModuleParse(raw)
+        for (var i = 0; i < root.watchedSources.length; i++) {
+            var moduleName = root.watchedSources[i]
+            var queueRaw   = logos.callModule(moduleName, "getInscriptionQueue", [])
+            var queue      = callModuleParse(queueRaw)
+            if (!Array.isArray(queue) || queue.length === 0) continue
 
-        if (!Array.isArray(entries)) { root.pollBusy = false; return }
-
-        for (var i = root.stashSeenCount; i < entries.length; i++) {
-            var e   = entries[i]
-            var cid = ""
-            if (e.cid && e.cid.length > 0) {
-                cid = e.cid
-            } else if (e.detail) {
-                cid = extractCid(e.detail)
-            }
-            if (cid !== "") {
-                var src = (e.source && e.source !== "stash") ? e.source : "notes"
-                if (root.watchedSources.indexOf(src) === -1) continue   // not whitelisted
-                appendActivity("detected " + cid + " from " + src, "info")
-                var lbl = e.detail ? e.detail : ("stash upload " + cid.substring(0, 12))
+            for (var j = 0; j < queue.length; j++) {
+                var entry = queue[j]
+                if (!entry.cid) continue
+                appendActivity("queued from " + moduleName + ": " + entry.cid.substring(0, 16) + "…", "info")
                 root.pollBusy = false
-                inscribeCid(cid, lbl, src)
+                inscribeCid(entry.cid, entry.label || entry.cid, moduleName)
                 root.pollBusy = true
+                logos.callModule(moduleName, "markInscribed", [entry.cid])
             }
         }
 
-        root.stashSeenCount = entries.length
-        root.pollBusy       = false
+        root.pollBusy = false
     }
 
     // ── Log refresh ───────────────────────────────────────────────────────────
@@ -495,9 +482,9 @@ Item {
     Timer {
         id: stashPollTimer
         interval: 10000
-        running:  true   // always running; pollStash() checks keycardConnected internally
+        running:  true   // always running; pollModules() checks keycardConnected internally
         repeat:   true
-        onTriggered: root.pollStash()
+        onTriggered: root.pollModules()
     }
 
     Timer {
@@ -859,7 +846,7 @@ Item {
                                         font.pixelSize: 12
                                         font.family: "monospace"
                                         wrapMode: TextArea.NoWrap
-                                        placeholderText: "notes\nkeeper"
+                                        placeholderText: "keeper"
                                         placeholderTextColor: root.textMuted
                                         background: null
                                         text: root.watchedSources.join("\n")

--- a/plugins/beacon_ui/Main.qml
+++ b/plugins/beacon_ui/Main.qml
@@ -247,11 +247,11 @@ Item {
 
         if (!pin || pin.error) {
             appendActivity("error: pinCid " + (pin ? pin.error : "null"), "error")
-            root.pollBusy = false; return
+            root.pollBusy = false; return false
         }
         if (pin.duplicate === true) {
             appendActivity("duplicate: " + cid.substring(0,16) + "…", "muted")
-            root.pollBusy = false; return
+            root.pollBusy = false; return true  // confirmed on-chain — caller should markInscribed
         }
 
         var entryIndex = pin.entryIndex
@@ -266,10 +266,6 @@ Item {
             status:        "pending"
         })
 
-        logos.callModule("liblogos_zone_sequencer_module", "set_signing_key", [useKey])
-        logos.callModule("liblogos_zone_sequencer_module", "set_checkpoint_path", [useCheckpoint])
-        logos.callModule("liblogos_zone_sequencer_module", "set_channel_id", [useChannelId])
-
         var payload = JSON.stringify({
             v:      1,
             type:   "cid_pin",
@@ -279,8 +275,16 @@ Item {
             ts:     Math.floor(Date.now() / 1000)
         })
 
-        var pubRaw    = logos.callModule("liblogos_zone_sequencer_module",
-                                         "publish", [payload])
+        var pubRaw
+        if (useChannelId === root.channelId) {
+            // Primary beacon channel — use the persistent sequencer handle (fast path)
+            pubRaw = logos.callModule("liblogos_zone_sequencer_module", "publish", [payload])
+        } else {
+            // Module sub-channel — use stateless publish_to so the correct channel is used.
+            // publish() would silently go to the primary handle regardless of set_channel_id.
+            pubRaw = logos.callModule("liblogos_zone_sequencer_module",
+                                      "publish_to", [useChannelId, useKey, useCheckpoint, payload])
+        }
         var pubResult = callModuleParse(pubRaw)
 
         var inscriptionId = ""
@@ -320,14 +324,6 @@ Item {
         else
             appendActivity("[" + (source || "primary") + "] inscription error — " + cid.substring(0,16) + "…", "error")
 
-        logos.callModule("liblogos_zone_sequencer_module",
-                         "set_signing_key", [root.signingKeyHex])
-        logos.callModule("liblogos_zone_sequencer_module",
-                         "set_checkpoint_path",
-                         [root.persistencePath + "/beacon.checkpoint"])
-        logos.callModule("liblogos_zone_sequencer_module",
-                         "set_channel_id", [root.channelId])
-
         // Manifest module channel to primary Beacon channel on first successful inscription
         if (status === "ok" && source && source.length > 0
                 && root.moduleChannels[source]
@@ -336,6 +332,7 @@ Item {
         }
 
         root.pollBusy = false
+        return status === "ok"
     }
 
     // ── Broadcast channel announce (kept for future use; not exposed in UI) ───
@@ -391,9 +388,10 @@ Item {
                 if (!entry.cid) continue
                 appendActivity("queued from " + moduleName + ": " + entry.cid.substring(0, 16) + "…", "info")
                 root.pollBusy = false
-                inscribeCid(entry.cid, entry.label || entry.cid, moduleName)
+                var inscribed = inscribeCid(entry.cid, entry.label || entry.cid, moduleName)
                 root.pollBusy = true
-                logos.callModule(moduleName, "markInscribed", [entry.cid])
+                if (inscribed)
+                    logos.callModule(moduleName, "markInscribed", [entry.cid])
             }
         }
 

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -11,43 +11,57 @@
 #include <QTextStream>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
 #include <QEventLoop>
 #include <QUrl>
 #include <algorithm>
 
 // ── QSettings key prefix ──────────────────────────────────────────────────────
-static constexpr const char* kNodeUrlKey       = "beacon/nodeUrl";
-static constexpr const char* kWatchStashKey    = "beacon/watchStash";
-static constexpr const char* kChannelLabelKey  = "beacon/channelLabel";
+static constexpr const char* kNodeUrlKey        = "beacon/nodeUrl";
+static constexpr const char* kWatchStashKey     = "beacon/watchStash";
+static constexpr const char* kChannelLabelKey   = "beacon/channelLabel";
 static constexpr const char* kWatchedSourcesKey = "beacon/watchedSources";
+static constexpr const char* kExplorerUrlKey    = "beacon/explorerUrl";
+static constexpr const char* kDefaultExplorerUrl = "https://testnet.blockchain.logos.co";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 QString BeaconPlugin::errorJson(const QString& msg)
 {
-    QJsonObject o;
-    o[QStringLiteral("error")] = msg;
+    QJsonObject o; o[QStringLiteral("error")] = msg;
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
 QString BeaconPlugin::okJson()
 {
-    QJsonObject o;
-    o[QStringLiteral("ok")] = true;
+    QJsonObject o; o[QStringLiteral("ok")] = true;
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
+QString BeaconPlugin::nodeUrl() const
+{
+    QSettings s;
+    QString url = s.value(QLatin1String(kNodeUrlKey),
+                          QStringLiteral("http://127.0.0.1:8080")).toString();
+    if (url.endsWith('/')) url.chop(1);
+    return url;
+}
+
+QString BeaconPlugin::explorerBaseUrl() const
+{
+    QSettings s;
+    QString url = s.value(QLatin1String(kExplorerUrlKey),
+                          QLatin1String(kDefaultExplorerUrl)).toString();
+    if (url.endsWith('/')) url.chop(1);
+    return url;
+}
+
 // ── Constructor ───────────────────────────────────────────────────────────────
-BeaconPlugin::BeaconPlugin(QObject* parent)
-    : QObject(parent)
-{}
+BeaconPlugin::BeaconPlugin(QObject* parent) : QObject(parent) {}
 
 // ── initLogos ─────────────────────────────────────────────────────────────────
 void BeaconPlugin::initLogos(LogosAPI* api)
 {
     logosAPI = api;
-
-    // Retrieve instancePersistencePath injected by the platform.
-    // Falls back to a sensible default if property is not available (e.g. in tests).
     QVariant prop = property("instancePersistencePath");
     if (prop.isValid() && !prop.toString().isEmpty()) {
         m_persistencePath = prop.toString();
@@ -55,30 +69,21 @@ void BeaconPlugin::initLogos(LogosAPI* api)
         m_persistencePath = QDir::homePath() +
             QStringLiteral("/.local/share/Logos/LogosBasecamp/module_data/logos_beacon");
     }
-
     QDir().mkpath(m_persistencePath);
-
-    // Load watched sources whitelist; default to ["notes"] if never set.
     QSettings s;
     m_watchedSources = s.value(QLatin1String(kWatchedSourcesKey)).toStringList();
-
     loadLog();
 }
 
-// ── setSigningKey ─────────────────────────────────────────────────────────────
-// Called from QML after keycardAuthComplete delivers the 32-byte domain key.
-// Replaces the old file-based ensureKey() — key now comes from hardware each session.
+// ── setSigningKey / clearSigningKey ───────────────────────────────────────────
 QString BeaconPlugin::setSigningKey(const QString& hexKey)
 {
     if (hexKey.length() != 64 || QByteArray::fromHex(hexKey.toUtf8()).size() != 32)
         return errorJson(QStringLiteral("hexKey must be 64 hex chars (32 bytes)"));
-
     m_signingKeyHex = hexKey;
     return okJson();
 }
 
-// ── clearSigningKey ───────────────────────────────────────────────────────────
-// Called from QML on card removal or auth restart.
 QString BeaconPlugin::clearSigningKey()
 {
     m_signingKeyHex.clear();
@@ -91,8 +96,7 @@ QString BeaconPlugin::diagLog(const QString& msg)
     QFile f(QStringLiteral("/tmp/beacon_plugin.diag"));
     if (f.open(QIODevice::WriteOnly | QIODevice::Append)) {
         QTextStream ts(&f);
-        ts << QDateTime::currentDateTime().toString(Qt::ISODateWithMs)
-           << " " << msg << "\n";
+        ts << QDateTime::currentDateTime().toString(Qt::ISODateWithMs) << " " << msg << "\n";
     }
     return okJson();
 }
@@ -120,7 +124,7 @@ QString BeaconPlugin::getBeaconConfig() const
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
-// ── setNodeUrl ────────────────────────────────────────────────────────────────
+// ── setNodeUrl / setWatchStash / setWatchedSources / getWatchedSources / setChannelLabel ──
 QString BeaconPlugin::setNodeUrl(const QString& url)
 {
     if (url.trimmed().isEmpty())
@@ -130,131 +134,115 @@ QString BeaconPlugin::setNodeUrl(const QString& url)
     return okJson();
 }
 
-// ── setWatchStash ─────────────────────────────────────────────────────────────
 QString BeaconPlugin::setWatchStash(bool enabled)
 {
-    QSettings s;
-    s.setValue(QLatin1String(kWatchStashKey), enabled);
-    return okJson();
+    QSettings s; s.setValue(QLatin1String(kWatchStashKey), enabled); return okJson();
 }
 
-// ── setWatchedSources ─────────────────────────────────────────────────────────
 QString BeaconPlugin::setWatchedSources(const QString& newlineSeparated)
 {
     m_watchedSources.clear();
-    const QStringList lines = newlineSeparated.split(QLatin1Char('\n'));
-    for (const QString& line : lines) {
-        const QString trimmed = line.trimmed();
-        if (!trimmed.isEmpty())
-            m_watchedSources.append(trimmed);
+    for (const QString& line : newlineSeparated.split(QLatin1Char('\n'))) {
+        const QString t = line.trimmed();
+        if (!t.isEmpty()) m_watchedSources.append(t);
     }
-    QSettings s;
-    s.setValue(QLatin1String(kWatchedSourcesKey), m_watchedSources);
+    QSettings s; s.setValue(QLatin1String(kWatchedSourcesKey), m_watchedSources);
     return okJson();
 }
 
-// ── getWatchedSources ─────────────────────────────────────────────────────────
 QString BeaconPlugin::getWatchedSources() const
 {
     QJsonArray arr;
-    for (const QString& src : m_watchedSources)
-        arr.append(src);
-    QJsonObject o;
-    o[QStringLiteral("sources")] = arr;
+    for (const QString& src : m_watchedSources) arr.append(src);
+    QJsonObject o; o[QStringLiteral("sources")] = arr;
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
-// ── setChannelLabel ───────────────────────────────────────────────────────────
 QString BeaconPlugin::setChannelLabel(const QString& label)
 {
-    QSettings s;
-    s.setValue(QLatin1String(kChannelLabelKey), label.trimmed());
-    return okJson();
+    QSettings s; s.setValue(QLatin1String(kChannelLabelKey), label.trimmed()); return okJson();
 }
 
 // ── getStatus ─────────────────────────────────────────────────────────────────
 QString BeaconPlugin::getStatus() const
 {
-    bool configured = !m_signingKeyHex.isEmpty();
-
     int inscribedCids = 0;
     for (int i = 0; i < m_log.size(); ++i) {
-        QJsonObject e = m_log[i].toObject();
-        if (e[QStringLiteral("status")].toString() == QLatin1String("ok"))
+        const QString st = m_log[i].toObject()[QStringLiteral("status")].toString();
+        if (st == QLatin1String("ok") || st == QLatin1String("confirmed"))
             ++inscribedCids;
     }
-
     QJsonObject o;
-    o[QStringLiteral("configured")]    = configured;
+    o[QStringLiteral("configured")]    = !m_signingKeyHex.isEmpty();
     o[QStringLiteral("seenCids")]      = m_log.size();
     o[QStringLiteral("inscribedCids")] = inscribedCids;
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
-// ── loadLog / saveLog ─────────────────────────────────────────────────────────
+// ── loadLog / saveLog / getInscriptionLog ─────────────────────────────────────
 void BeaconPlugin::loadLog()
 {
-    if (m_persistencePath.isEmpty())
-        return;
-
-    QString logPath = m_persistencePath + QStringLiteral("/inscription-log.json");
-    QFile f(logPath);
-    if (!f.open(QIODevice::ReadOnly))
-        return;
-
+    if (m_persistencePath.isEmpty()) return;
+    QFile f(m_persistencePath + QStringLiteral("/inscription-log.json"));
+    if (!f.open(QIODevice::ReadOnly)) return;
     QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
-    if (doc.isArray())
-        m_log = doc.array();
+    if (doc.isArray()) m_log = doc.array();
 }
 
 void BeaconPlugin::saveLog()
 {
-    if (m_persistencePath.isEmpty())
-        return;
-
-    QString logPath = m_persistencePath + QStringLiteral("/inscription-log.json");
-    QFile f(logPath);
-    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+    if (m_persistencePath.isEmpty()) return;
+    QFile f(m_persistencePath + QStringLiteral("/inscription-log.json"));
+    if (f.open(QIODevice::WriteOnly | QIODevice::Truncate))
         f.write(QJsonDocument(m_log).toJson(QJsonDocument::Compact));
-    }
 }
 
-// ── getInscriptionLog ─────────────────────────────────────────────────────────
 QString BeaconPlugin::getInscriptionLog() const
 {
-    // Return last 100 entries
     if (m_log.size() <= 100)
         return QJsonDocument(m_log).toJson(QJsonDocument::Compact);
-
     QJsonArray tail;
-    int start = m_log.size() - 100;
-    for (int i = start; i < m_log.size(); ++i)
-        tail.append(m_log[i]);
+    for (int i = m_log.size() - 100; i < m_log.size(); ++i) tail.append(m_log[i]);
     return QJsonDocument(tail).toJson(QJsonDocument::Compact);
+}
+
+// ── getNodeInfo ───────────────────────────────────────────────────────────────
+QString BeaconPlugin::getNodeInfo()
+{
+    if (!m_nam) m_nam = new QNetworkAccessManager(this);
+    QNetworkReply* reply = m_nam->get(QNetworkRequest{QUrl(nodeUrl() + QStringLiteral("/cryptarchia/info"))});
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+    if (reply->error() != QNetworkReply::NoError) {
+        const QString err = reply->errorString(); reply->deleteLater();
+        return errorJson(err);
+    }
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+    reply->deleteLater();
+    if (!doc.isObject()) return errorJson(QStringLiteral("unexpected node response"));
+    QJsonObject src = doc.object(), o;
+    o[QStringLiteral("slot")]     = src[QStringLiteral("slot")];
+    o[QStringLiteral("lib_slot")] = src[QStringLiteral("lib_slot")];
+    o[QStringLiteral("mode")]     = src[QStringLiteral("mode")];
+    return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
 // ── pinCid ────────────────────────────────────────────────────────────────────
 QString BeaconPlugin::pinCid(const QString& cid, const QString& label,
-                              const QString& source)
+                              const QString& source, int slotFrom, int libAtSubmit)
 {
     if (cid.trimmed().isEmpty())
         return errorJson(QStringLiteral("cid must not be empty"));
 
-    // Duplicate guard: only block if already confirmed on-chain (inscriptionId set).
-    // Pending entries (inscriptionId empty) are re-tried — they were never published.
     for (int i = 0; i < m_log.size(); ++i) {
         QJsonObject e = m_log[i].toObject();
         if (e[QStringLiteral("cid")].toString() == cid) {
             if (!e[QStringLiteral("inscriptionId")].toString().isEmpty()) {
-                QJsonObject o;
-                o[QStringLiteral("ok")]        = true;
-                o[QStringLiteral("duplicate")] = true;
+                QJsonObject o; o[QStringLiteral("ok")] = true; o[QStringLiteral("duplicate")] = true;
                 return QJsonDocument(o).toJson(QJsonDocument::Compact);
             }
-            // Pending — remove stale entry, fall through to re-inscribe below.
-            m_log.removeAt(i);
-            saveLog();
-            break;
+            m_log.removeAt(i); saveLog(); break;
         }
     }
 
@@ -263,31 +251,27 @@ QString BeaconPlugin::pinCid(const QString& cid, const QString& label,
     entry[QStringLiteral("label")]         = label;
     entry[QStringLiteral("source")]        = source;
     entry[QStringLiteral("ts")]            = QDateTime::currentSecsSinceEpoch();
-    entry[QStringLiteral("status")]        = QStringLiteral("pending");
+    entry[QStringLiteral("status")]        = QStringLiteral("queued");
     entry[QStringLiteral("inscriptionId")] = QString();
+    entry[QStringLiteral("slotFrom")]      = slotFrom;
+    entry[QStringLiteral("libAtSubmit")]   = libAtSubmit;
 
-    int entryIndex = m_log.size();
+    int idx = m_log.size();
     m_log.append(entry);
     saveLog();
 
-    QJsonObject o;
-    o[QStringLiteral("ok")]         = true;
-    o[QStringLiteral("entryIndex")] = entryIndex;
+    QJsonObject o; o[QStringLiteral("ok")] = true; o[QStringLiteral("entryIndex")] = idx;
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
 // ── deriveModuleSigningKey ────────────────────────────────────────────────────
 QString BeaconPlugin::deriveModuleSigningKey(const QString& moduleName)
 {
-    if (m_signingKeyHex.isEmpty())
-        return errorJson(QStringLiteral("key not set"));
-
-    QByteArray masterKeyBytes  = QByteArray::fromHex(m_signingKeyHex.toUtf8());
-    QByteArray moduleNameUtf8  = moduleName.toUtf8();
-    QByteArray derived = QCryptographicHash::hash(masterKeyBytes + moduleNameUtf8,
-                                                  QCryptographicHash::Sha256);
-    QJsonObject o;
-    o[QStringLiteral("signingKey")] = QString::fromLatin1(derived.toHex());
+    if (m_signingKeyHex.isEmpty()) return errorJson(QStringLiteral("key not set"));
+    QByteArray derived = QCryptographicHash::hash(
+        QByteArray::fromHex(m_signingKeyHex.toUtf8()) + moduleName.toUtf8(),
+        QCryptographicHash::Sha256);
+    QJsonObject o; o[QStringLiteral("signingKey")] = QString::fromLatin1(derived.toHex());
     return QJsonDocument(o).toJson(QJsonDocument::Compact);
 }
 
@@ -295,52 +279,37 @@ QString BeaconPlugin::deriveModuleSigningKey(const QString& moduleName)
 QString BeaconPlugin::getModules()
 {
     QMap<QString, QJsonObject> groups;
-
     for (int i = 0; i < m_log.size(); ++i) {
-        QJsonObject e      = m_log[i].toObject();
-        QString     source = e[QStringLiteral("source")].toString();
-
-        if (!groups.contains(source)) {
-            QJsonObject g;
-            g[QStringLiteral("name")]     = source;
-            g[QStringLiteral("cidCount")] = 0;
-            g[QStringLiteral("lastTs")]   = qint64(0);
-            groups[source] = g;
+        QJsonObject e = m_log[i].toObject();
+        QString src = e[QStringLiteral("source")].toString();
+        if (!groups.contains(src)) {
+            QJsonObject g; g[QStringLiteral("name")] = src;
+            g[QStringLiteral("cidCount")] = 0; g[QStringLiteral("lastTs")] = qint64(0);
+            groups[src] = g;
         }
-
-        QJsonObject g = groups[source];
+        QJsonObject g = groups[src];
         g[QStringLiteral("cidCount")] = g[QStringLiteral("cidCount")].toInt() + 1;
-
         qint64 ts = e[QStringLiteral("ts")].toVariant().toLongLong();
         if (ts > g[QStringLiteral("lastTs")].toVariant().toLongLong())
             g[QStringLiteral("lastTs")] = ts;
-
-        groups[source] = g;
+        groups[src] = g;
     }
-
     QList<QJsonObject> list = groups.values();
     std::sort(list.begin(), list.end(), [](const QJsonObject& a, const QJsonObject& b) {
         return a[QStringLiteral("lastTs")].toVariant().toLongLong() >
                b[QStringLiteral("lastTs")].toVariant().toLongLong();
     });
-
     QJsonArray arr;
-    for (const auto& g : list)
-        arr.append(g);
-
+    for (const auto& g : list) arr.append(g);
     return QJsonDocument(arr).toJson(QJsonDocument::Compact);
 }
 
 // ── ensureCheckpointsDir ──────────────────────────────────────────────────────
 QString BeaconPlugin::ensureCheckpointsDir()
 {
-    if (m_persistencePath.isEmpty())
-        return errorJson(QStringLiteral("persistence path not set"));
-
-    QDir dir(m_persistencePath + QStringLiteral("/checkpoints"));
-    if (dir.mkpath(QStringLiteral(".")))
+    if (m_persistencePath.isEmpty()) return errorJson(QStringLiteral("persistence path not set"));
+    if (QDir(m_persistencePath + QStringLiteral("/checkpoints")).mkpath(QStringLiteral(".")))
         return okJson();
-
     return errorJson(QStringLiteral("failed to create checkpoints dir"));
 }
 
@@ -351,124 +320,205 @@ QString BeaconPlugin::confirmInscription(int entryIndex,
 {
     if (entryIndex < 0 || entryIndex >= m_log.size())
         return errorJson(QStringLiteral("entryIndex out of range"));
-
     QJsonObject entry = m_log[entryIndex].toObject();
     entry[QStringLiteral("inscriptionId")] = inscriptionId;
     entry[QStringLiteral("status")]        = status;
     m_log[entryIndex] = entry;
     saveLog();
-
     emit inscriptionConfirmed(entryIndex, inscriptionId, status);
-
     return okJson();
 }
 
 // ── findAnchorTx ──────────────────────────────────────────────────────────────
-QString BeaconPlugin::findAnchorTx(const QString& nodeUrl,
+QString BeaconPlugin::findAnchorTx(const QString& nUrl,
                                     const QString& channelId,
-                                    int slotFrom,
-                                    int slotTo)
+                                    int slotFrom, int slotTo)
 {
-    QJsonObject result;
-    result[QStringLiteral("txHash")] = QString();
-
-    if (!m_nam)
-        m_nam = new QNetworkAccessManager(this);
-
-    QString url = QString("%1/cryptarchia/blocks?slot_from=%2&slot_to=%3")
-                      .arg(nodeUrl.endsWith('/') ? nodeUrl.chopped(1) : nodeUrl)
-                      .arg(slotFrom)
-                      .arg(slotTo);
-
-    QNetworkRequest req{QUrl(url)};
-    QNetworkReply* reply = m_nam->get(req);
-
-    QEventLoop loop;
-    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
-    loop.exec();
-
-    if (reply->error() != QNetworkReply::NoError) {
-        reply->deleteLater();
-        return QJsonDocument(result).toJson(QJsonDocument::Compact);
-    }
-
-    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
-    reply->deleteLater();
-
-    if (!doc.isArray())
-        return QJsonDocument(result).toJson(QJsonDocument::Compact);
-
-    // Walk blocks oldest→newest; return the first ChannelInscribe tx for channelId.
-    const QJsonArray blocks = doc.array();
-    for (const QJsonValue& bv : blocks) {
-        const QJsonArray txs = bv[QStringLiteral("transactions")].toArray();
-        for (const QJsonValue& tv : txs) {
-            const QJsonObject mtx  = tv[QStringLiteral("mantle_tx")].toObject();
-            const QString     hash = mtx[QStringLiteral("hash")].toString();
-            const QJsonArray  ops  = mtx[QStringLiteral("ops")].toArray();
-            for (const QJsonValue& ov : ops) {
-                const QJsonObject payload = ov[QStringLiteral("payload")].toObject();
-                if (payload[QStringLiteral("channel_id")].toString() == channelId) {
-                    result[QStringLiteral("txHash")] = hash;
+    QJsonObject result; result[QStringLiteral("txHash")] = QString();
+    if (!m_nam) m_nam = new QNetworkAccessManager(this);
+    QString base = nUrl; if (base.endsWith('/')) base.chop(1);
+    QString url = QString("%1/cryptarchia/blocks?slot_from=%2&slot_to=%3").arg(base).arg(slotFrom).arg(slotTo);
+    QNetworkReply* reply = m_nam->get(QNetworkRequest{QUrl(url)});
+    QEventLoop loop; QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit); loop.exec();
+    if (reply->error() != QNetworkReply::NoError) { reply->deleteLater(); return QJsonDocument(result).toJson(QJsonDocument::Compact); }
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll()); reply->deleteLater();
+    if (!doc.isArray()) return QJsonDocument(result).toJson(QJsonDocument::Compact);
+    for (const QJsonValue& bv : doc.array()) {
+        for (const QJsonValue& tv : bv[QStringLiteral("transactions")].toArray()) {
+            const QJsonObject mtx = tv[QStringLiteral("mantle_tx")].toObject();
+            for (const QJsonValue& ov : mtx[QStringLiteral("ops")].toArray()) {
+                if (ov[QStringLiteral("payload")][QStringLiteral("channel_id")].toString() == channelId) {
+                    result[QStringLiteral("txHash")] = mtx[QStringLiteral("hash")].toString();
                     return QJsonDocument(result).toJson(QJsonDocument::Compact);
                 }
             }
         }
     }
-
     return QJsonDocument(result).toJson(QJsonDocument::Compact);
 }
 
-// ── getManifestLog ────────────────────────────────────────────────────────────
-// Returns a JSON array of module names that have been manifested to the primary
-// Beacon channel, e.g. ["notes", "stash"]. Loaded from manifest-log.json.
-QString BeaconPlugin::getManifestLog() const
+// ── findExplorerTxHash ────────────────────────────────────────────────────────
+// 1) Scan node blocks [slotFrom, slotTo] for tx matching channelId → get block.header.id + tx index.
+// 2) Query explorer /blocks/{blockId}?fork=N → get real explorer TX hash at that index.
+QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
+                                          int slotFrom, int slotTo)
 {
-    if (m_persistencePath.isEmpty())
-        return QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
+    QJsonObject result;
+    result[QStringLiteral("txHash")]    = QString();
+    result[QStringLiteral("blockHash")] = QString();
+    result[QStringLiteral("found")]     = false;
 
-    QString path = m_persistencePath + QStringLiteral("/manifest-log.json");
-    QFile f(path);
-    if (!f.open(QIODevice::ReadOnly))
-        return QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
+    if (channelId.isEmpty() || slotFrom <= 0)
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
 
-    QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
-    if (doc.isArray())
-        return QJsonDocument(doc.array()).toJson(QJsonDocument::Compact);
+    if (!m_nam) m_nam = new QNetworkAccessManager(this);
 
-    return QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
-}
+    // ── Step 1: scan node blocks ──────────────────────────────────────────────
+    auto getReply = [&](const QString& url) -> QNetworkReply* {
+        QNetworkReply* r = m_nam->get(QNetworkRequest{QUrl(url)});
+        QEventLoop loop;
+        QObject::connect(r, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+        return r;
+    };
 
-// ── recordManifest ────────────────────────────────────────────────────────────
-// Appends moduleName to manifest-log.json if not already present.
-QString BeaconPlugin::recordManifest(const QString& moduleName)
-{
-    if (m_persistencePath.isEmpty())
-        return errorJson(QStringLiteral("persistence path not set"));
+    QNetworkReply* blocksReply = getReply(
+        QString("%1/cryptarchia/blocks?slot_from=%2&slot_to=%3")
+            .arg(nodeUrl()).arg(slotFrom).arg(slotTo));
 
-    QString path = m_persistencePath + QStringLiteral("/manifest-log.json");
+    if (blocksReply->error() != QNetworkReply::NoError) {
+        blocksReply->deleteLater();
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
+    }
+    QJsonDocument blocksDoc = QJsonDocument::fromJson(blocksReply->readAll());
+    blocksReply->deleteLater();
 
-    // Load existing
-    QJsonArray arr;
-    QFile rf(path);
-    if (rf.open(QIODevice::ReadOnly)) {
-        QJsonDocument doc = QJsonDocument::fromJson(rf.readAll());
-        if (doc.isArray())
-            arr = doc.array();
-        rf.close();
+    if (!blocksDoc.isArray())
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
+
+    QString blockHeaderId;
+    int     txIndex = -1;
+
+    for (const QJsonValue& bv : blocksDoc.array()) {
+        const QJsonObject block = bv.toObject();
+        const QString     bid   = block[QStringLiteral("header")][QStringLiteral("id")].toString();
+        const QJsonArray  txs   = block[QStringLiteral("transactions")].toArray();
+        for (int ti = 0; ti < txs.size(); ++ti) {
+            const QJsonArray ops = txs[ti][QStringLiteral("mantle_tx")]
+                                       [QStringLiteral("ops")].toArray();
+            for (const QJsonValue& ov : ops) {
+                if (ov[QStringLiteral("payload")][QStringLiteral("channel_id")].toString() == channelId) {
+                    blockHeaderId = bid;
+                    txIndex       = ti;
+                    goto found_block;
+                }
+            }
+        }
+    }
+    return QJsonDocument(result).toJson(QJsonDocument::Compact);  // not found
+
+found_block:
+    result[QStringLiteral("blockHash")] = blockHeaderId;
+
+    // ── Step 2: get current fork ──────────────────────────────────────────────
+    int fork = 0;
+    {
+        QNetworkReply* fr = getReply(explorerBaseUrl() + QStringLiteral("/web/explorer/api/v1/fork-choice"));
+        if (fr->error() == QNetworkReply::NoError)
+            fork = QJsonDocument::fromJson(fr->readAll())[QStringLiteral("fork")].toInt(0);
+        fr->deleteLater();
     }
 
-    // Idempotent: only append if not already present
-    for (int i = 0; i < arr.size(); ++i)
-        if (arr[i].toString() == moduleName)
-            return okJson();
+    // ── Step 3: query explorer block → real TX hash ───────────────────────────
+    QNetworkReply* exReply = getReply(
+        QString("%1/web/explorer/api/v1/blocks/%2?fork=%3")
+            .arg(explorerBaseUrl(), blockHeaderId).arg(fork));
 
+    if (exReply->error() != QNetworkReply::NoError) {
+        exReply->deleteLater();
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
+    }
+    QJsonDocument exDoc = QJsonDocument::fromJson(exReply->readAll());
+    exReply->deleteLater();
+
+    const QJsonArray exTxs = exDoc[QStringLiteral("transactions")].toArray();
+    if (txIndex >= 0 && txIndex < exTxs.size()) {
+        const QString txHash = exTxs[txIndex][QStringLiteral("hash")].toString();
+        if (!txHash.isEmpty()) {
+            result[QStringLiteral("txHash")] = txHash;
+            result[QStringLiteral("found")]  = true;
+        }
+    }
+    return QJsonDocument(result).toJson(QJsonDocument::Compact);
+}
+
+// ── getBlockForTx ─────────────────────────────────────────────────────────────
+QString BeaconPlugin::getBlockForTx(const QString& txHash, int slotFrom)
+{
+    QJsonObject result;
+    result[QStringLiteral("blockHash")] = QString();
+    result[QStringLiteral("found")]     = false;
+    if (txHash.isEmpty()) return QJsonDocument(result).toJson(QJsonDocument::Compact);
+
+    if (!m_nam) m_nam = new QNetworkAccessManager(this);
+
+    auto getReply = [&](const QString& url) -> QNetworkReply* {
+        QNetworkReply* r = m_nam->get(QNetworkRequest{QUrl(url)});
+        QEventLoop loop;
+        QObject::connect(r, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+        return r;
+    };
+
+    QNetworkReply* infoReply = getReply(nodeUrl() + QStringLiteral("/cryptarchia/info"));
+    if (infoReply->error() != QNetworkReply::NoError) { infoReply->deleteLater(); return QJsonDocument(result).toJson(QJsonDocument::Compact); }
+    QJsonDocument infoDoc = QJsonDocument::fromJson(infoReply->readAll()); infoReply->deleteLater();
+    int libSlot = infoDoc[QStringLiteral("lib_slot")].toInt(0);
+    if (libSlot <= 0) return QJsonDocument(result).toJson(QJsonDocument::Compact);
+
+    int scanFrom = (slotFrom > 0) ? slotFrom : qMax(0, libSlot - 5000);
+
+    QNetworkReply* blocksReply = getReply(
+        QString("%1/cryptarchia/blocks?slot_from=%2&slot_to=%3").arg(nodeUrl()).arg(scanFrom).arg(libSlot));
+    if (blocksReply->error() != QNetworkReply::NoError) { blocksReply->deleteLater(); return QJsonDocument(result).toJson(QJsonDocument::Compact); }
+    QJsonDocument blocksDoc = QJsonDocument::fromJson(blocksReply->readAll()); blocksReply->deleteLater();
+    if (!blocksDoc.isArray()) return QJsonDocument(result).toJson(QJsonDocument::Compact);
+
+    for (const QJsonValue& bv : blocksDoc.array()) {
+        const QJsonObject block = bv.toObject();
+        const QString headerId  = block[QStringLiteral("header")][QStringLiteral("id")].toString();
+        for (const QJsonValue& tv : block[QStringLiteral("transactions")].toArray()) {
+            if (tv[QStringLiteral("mantle_tx")][QStringLiteral("hash")].toString() == txHash) {
+                result[QStringLiteral("blockHash")] = headerId;
+                result[QStringLiteral("found")]     = true;
+                return QJsonDocument(result).toJson(QJsonDocument::Compact);
+            }
+        }
+    }
+    return QJsonDocument(result).toJson(QJsonDocument::Compact);
+}
+
+// ── getManifestLog / recordManifest ───────────────────────────────────────────
+QString BeaconPlugin::getManifestLog() const
+{
+    if (m_persistencePath.isEmpty()) return QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
+    QFile f(m_persistencePath + QStringLiteral("/manifest-log.json"));
+    if (!f.open(QIODevice::ReadOnly)) return QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    return doc.isArray() ? QJsonDocument(doc.array()).toJson(QJsonDocument::Compact)
+                         : QJsonDocument(QJsonArray()).toJson(QJsonDocument::Compact);
+}
+
+QString BeaconPlugin::recordManifest(const QString& moduleName)
+{
+    if (m_persistencePath.isEmpty()) return errorJson(QStringLiteral("persistence path not set"));
+    QString path = m_persistencePath + QStringLiteral("/manifest-log.json");
+    QJsonArray arr;
+    { QFile rf(path); if (rf.open(QIODevice::ReadOnly)) { QJsonDocument doc = QJsonDocument::fromJson(rf.readAll()); if (doc.isArray()) arr = doc.array(); } }
+    for (int i = 0; i < arr.size(); ++i) if (arr[i].toString() == moduleName) return okJson();
     arr.append(moduleName);
-
     QFile wf(path);
-    if (!wf.open(QIODevice::WriteOnly | QIODevice::Truncate))
-        return errorJson(QStringLiteral("failed to write manifest-log.json"));
-
+    if (!wf.open(QIODevice::WriteOnly | QIODevice::Truncate)) return errorJson(QStringLiteral("failed to write manifest-log.json"));
     wf.write(QJsonDocument(arr).toJson(QJsonDocument::Compact));
     return okJson();
 }

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -396,10 +396,10 @@ QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
     if (!blocksDoc.isArray())
         return QJsonDocument(result).toJson(QJsonDocument::Compact);
 
-    // mantle_tx.hash == explorer hash (confirmed; zone_sequencer TxHash is different)
-    // We read it directly from the block scan — no need for a separate explorer round-trip.
+    // NOTE: mantle_tx.hash from node != explorer hash (node may compute Poseidon2 differently).
+    // Step 1: find the block containing our channelId inscription via node scan.
+    // Step 2: query explorer block API to get the real explorer tx hash.
     QString blockHeaderId;
-    QString txHash;
 
     for (const QJsonValue& bv : blocksDoc.array()) {
         const QJsonObject block = bv.toObject();
@@ -410,8 +410,6 @@ QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
             for (const QJsonValue& ov : ops) {
                 if (ov[QStringLiteral("payload")][QStringLiteral("channel_id")].toString() == channelId) {
                     blockHeaderId = bid;
-                    txHash        = tv[QStringLiteral("mantle_tx")]
-                                      [QStringLiteral("hash")].toString();
                     goto found_block;
                 }
             }
@@ -420,6 +418,34 @@ QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
     return QJsonDocument(result).toJson(QJsonDocument::Compact);  // not found
 
 found_block:
+    // ── Step 2: get real tx hash from explorer block API ─────────────────────
+    QNetworkReply* forkReply = getReply(
+        explorerBaseUrl() + QStringLiteral("/web/explorer/api/v1/fork-choice"));
+    int fork = 0;
+    if (forkReply->error() == QNetworkReply::NoError) {
+        fork = QJsonDocument::fromJson(forkReply->readAll())[QStringLiteral("fork")].toInt(0);
+    }
+    forkReply->deleteLater();
+
+    QNetworkReply* explorerReply = getReply(
+        QString("%1/web/explorer/api/v1/blocks/%2?fork=%3")
+            .arg(explorerBaseUrl(), blockHeaderId).arg(fork));
+
+    QString txHash;
+    if (explorerReply->error() == QNetworkReply::NoError) {
+        QJsonDocument ed = QJsonDocument::fromJson(explorerReply->readAll());
+        for (const QJsonValue& tv : ed[QStringLiteral("transactions")].toArray()) {
+            for (const QJsonValue& ov : tv[QStringLiteral("operations")].toArray()) {
+                if (ov[QStringLiteral("content")][QStringLiteral("channel_id")].toString() == channelId) {
+                    txHash = tv[QStringLiteral("hash")].toString();
+                    break;
+                }
+            }
+            if (!txHash.isEmpty()) break;
+        }
+    }
+    explorerReply->deleteLater();
+
     if (!txHash.isEmpty()) {
         result[QStringLiteral("txHash")]    = txHash;
         result[QStringLiteral("blockHash")] = blockHeaderId;

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -228,14 +228,21 @@ QString BeaconPlugin::pinCid(const QString& cid, const QString& label,
     if (cid.trimmed().isEmpty())
         return errorJson(QStringLiteral("cid must not be empty"));
 
-    // Duplicate guard: check if CID already in log
+    // Duplicate guard: only block if already confirmed on-chain (inscriptionId set).
+    // Pending entries (inscriptionId empty) are re-tried — they were never published.
     for (int i = 0; i < m_log.size(); ++i) {
         QJsonObject e = m_log[i].toObject();
         if (e[QStringLiteral("cid")].toString() == cid) {
-            QJsonObject o;
-            o[QStringLiteral("ok")]        = true;
-            o[QStringLiteral("duplicate")] = true;
-            return QJsonDocument(o).toJson(QJsonDocument::Compact);
+            if (!e[QStringLiteral("inscriptionId")].toString().isEmpty()) {
+                QJsonObject o;
+                o[QStringLiteral("ok")]        = true;
+                o[QStringLiteral("duplicate")] = true;
+                return QJsonDocument(o).toJson(QJsonDocument::Compact);
+            }
+            // Pending — remove stale entry, fall through to re-inscribe below.
+            m_log.removeAt(i);
+            saveLog();
+            break;
         }
     }
 

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -9,6 +9,10 @@
 #include <QDir>
 #include <QCryptographicHash>
 #include <QTextStream>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkReply>
+#include <QEventLoop>
+#include <QUrl>
 #include <algorithm>
 
 // ── QSettings key prefix ──────────────────────────────────────────────────────
@@ -349,6 +353,62 @@ QString BeaconPlugin::confirmInscription(int entryIndex,
     emit inscriptionConfirmed(entryIndex, inscriptionId, status);
 
     return okJson();
+}
+
+// ── findAnchorTx ──────────────────────────────────────────────────────────────
+QString BeaconPlugin::findAnchorTx(const QString& nodeUrl,
+                                    const QString& channelId,
+                                    int slotFrom,
+                                    int slotTo)
+{
+    QJsonObject result;
+    result[QStringLiteral("txHash")] = QString();
+
+    if (!m_nam)
+        m_nam = new QNetworkAccessManager(this);
+
+    QString url = QString("%1/cryptarchia/blocks?slot_from=%2&slot_to=%3")
+                      .arg(nodeUrl.endsWith('/') ? nodeUrl.chopped(1) : nodeUrl)
+                      .arg(slotFrom)
+                      .arg(slotTo);
+
+    QNetworkRequest req{QUrl(url)};
+    QNetworkReply* reply = m_nam->get(req);
+
+    QEventLoop loop;
+    QObject::connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        reply->deleteLater();
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
+    }
+
+    QJsonDocument doc = QJsonDocument::fromJson(reply->readAll());
+    reply->deleteLater();
+
+    if (!doc.isArray())
+        return QJsonDocument(result).toJson(QJsonDocument::Compact);
+
+    // Walk blocks oldest→newest; return the first ChannelInscribe tx for channelId.
+    const QJsonArray blocks = doc.array();
+    for (const QJsonValue& bv : blocks) {
+        const QJsonArray txs = bv[QStringLiteral("transactions")].toArray();
+        for (const QJsonValue& tv : txs) {
+            const QJsonObject mtx  = tv[QStringLiteral("mantle_tx")].toObject();
+            const QString     hash = mtx[QStringLiteral("hash")].toString();
+            const QJsonArray  ops  = mtx[QStringLiteral("ops")].toArray();
+            for (const QJsonValue& ov : ops) {
+                const QJsonObject payload = ov[QStringLiteral("payload")].toObject();
+                if (payload[QStringLiteral("channel_id")].toString() == channelId) {
+                    result[QStringLiteral("txHash")] = hash;
+                    return QJsonDocument(result).toJson(QJsonDocument::Compact);
+                }
+            }
+        }
+    }
+
+    return QJsonDocument(result).toJson(QJsonDocument::Compact);
 }
 
 // ── getManifestLog ────────────────────────────────────────────────────────────

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -97,6 +97,14 @@ QString BeaconPlugin::diagLog(const QString& msg)
     return okJson();
 }
 
+// ── clearInscriptionLog ───────────────────────────────────────────────────────
+QString BeaconPlugin::clearInscriptionLog()
+{
+    m_log = QJsonArray();
+    saveLog();
+    return okJson();
+}
+
 // ── getBeaconConfig ───────────────────────────────────────────────────────────
 QString BeaconPlugin::getBeaconConfig() const
 {

--- a/src/plugin/BeaconPlugin.cpp
+++ b/src/plugin/BeaconPlugin.cpp
@@ -396,20 +396,22 @@ QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
     if (!blocksDoc.isArray())
         return QJsonDocument(result).toJson(QJsonDocument::Compact);
 
+    // mantle_tx.hash == explorer hash (confirmed; zone_sequencer TxHash is different)
+    // We read it directly from the block scan — no need for a separate explorer round-trip.
     QString blockHeaderId;
-    int     txIndex = -1;
+    QString txHash;
 
     for (const QJsonValue& bv : blocksDoc.array()) {
         const QJsonObject block = bv.toObject();
         const QString     bid   = block[QStringLiteral("header")][QStringLiteral("id")].toString();
-        const QJsonArray  txs   = block[QStringLiteral("transactions")].toArray();
-        for (int ti = 0; ti < txs.size(); ++ti) {
-            const QJsonArray ops = txs[ti][QStringLiteral("mantle_tx")]
-                                       [QStringLiteral("ops")].toArray();
+        for (const QJsonValue& tv : block[QStringLiteral("transactions")].toArray()) {
+            const QJsonArray ops = tv[QStringLiteral("mantle_tx")]
+                                     [QStringLiteral("ops")].toArray();
             for (const QJsonValue& ov : ops) {
                 if (ov[QStringLiteral("payload")][QStringLiteral("channel_id")].toString() == channelId) {
                     blockHeaderId = bid;
-                    txIndex       = ti;
+                    txHash        = tv[QStringLiteral("mantle_tx")]
+                                      [QStringLiteral("hash")].toString();
                     goto found_block;
                 }
             }
@@ -418,36 +420,10 @@ QString BeaconPlugin::findExplorerTxHash(const QString& channelId,
     return QJsonDocument(result).toJson(QJsonDocument::Compact);  // not found
 
 found_block:
-    result[QStringLiteral("blockHash")] = blockHeaderId;
-
-    // ── Step 2: get current fork ──────────────────────────────────────────────
-    int fork = 0;
-    {
-        QNetworkReply* fr = getReply(explorerBaseUrl() + QStringLiteral("/web/explorer/api/v1/fork-choice"));
-        if (fr->error() == QNetworkReply::NoError)
-            fork = QJsonDocument::fromJson(fr->readAll())[QStringLiteral("fork")].toInt(0);
-        fr->deleteLater();
-    }
-
-    // ── Step 3: query explorer block → real TX hash ───────────────────────────
-    QNetworkReply* exReply = getReply(
-        QString("%1/web/explorer/api/v1/blocks/%2?fork=%3")
-            .arg(explorerBaseUrl(), blockHeaderId).arg(fork));
-
-    if (exReply->error() != QNetworkReply::NoError) {
-        exReply->deleteLater();
-        return QJsonDocument(result).toJson(QJsonDocument::Compact);
-    }
-    QJsonDocument exDoc = QJsonDocument::fromJson(exReply->readAll());
-    exReply->deleteLater();
-
-    const QJsonArray exTxs = exDoc[QStringLiteral("transactions")].toArray();
-    if (txIndex >= 0 && txIndex < exTxs.size()) {
-        const QString txHash = exTxs[txIndex][QStringLiteral("hash")].toString();
-        if (!txHash.isEmpty()) {
-            result[QStringLiteral("txHash")] = txHash;
-            result[QStringLiteral("found")]  = true;
-        }
+    if (!txHash.isEmpty()) {
+        result[QStringLiteral("txHash")]    = txHash;
+        result[QStringLiteral("blockHash")] = blockHeaderId;
+        result[QStringLiteral("found")]     = true;
     }
     return QJsonDocument(result).toJson(QJsonDocument::Compact);
 }

--- a/src/plugin/BeaconPlugin.h
+++ b/src/plugin/BeaconPlugin.h
@@ -46,14 +46,23 @@ public:
     // Returns {configured:bool, seenCids:N, inscribedCids:N}
     Q_INVOKABLE QString getStatus() const;
 
-    // Returns JSON array [{cid, inscriptionId, label, ts, status}], last 100
+    // Returns JSON array [{cid, inscriptionId, label, source, ts, status,
+    //   slotFrom, libAtSubmit}], last 100 entries.
     Q_INVOKABLE QString getInscriptionLog() const;
+
+    // ── Node info ────────────────────────────────────────────────────────────
+    // Queries GET {nodeUrl}/cryptarchia/info.
+    // Returns {"slot":N,"lib_slot":N,"mode":"Online"} or {"error":"..."}
+    Q_INVOKABLE QString getNodeInfo();
 
     // ── Inscription ──────────────────────────────────────────────────────────
     // Checks for duplicate, appends pending entry, saves.
+    // slotFrom: node slot at time of inscription (for finalization progress).
+    // libAtSubmit: lib_slot at time of inscription (progress bar start).
     // Returns {"ok":true,"entryIndex":N} | {"ok":true,"duplicate":true} | {"error":"..."}
     Q_INVOKABLE QString pinCid(const QString& cid, const QString& label,
-                               const QString& source = "");
+                               const QString& source = "",
+                               int slotFrom = 0, int libAtSubmit = 0);
 
     // Derives a per-module signing key via SHA256(master_key || module_name).
     // Returns {"signingKey":"<64-char-hex>"} or {"error":"key not set"}
@@ -65,7 +74,9 @@ public:
     // Creates {persistencePath}/checkpoints/ directory. Returns {"ok":true} or {"error":"..."}
     Q_INVOKABLE QString ensureCheckpointsDir();
 
-    // Called from QML after zone seq responds. Updates entry status.
+    // Called from QML to update entry status at any lifecycle stage.
+    // status: "submitted" | "finalizing" | "confirmed" | "failed" | "error"
+    // inscriptionId: explorer TX hash when status="confirmed", empty otherwise.
     // Returns {"ok":true} or {"error":"..."}
     Q_INVOKABLE QString confirmInscription(int entryIndex,
                                            const QString& inscriptionId,
@@ -98,6 +109,18 @@ public:
                                      int slotFrom,
                                      int slotTo);
 
+    // Scans node blocks [slotFrom, lib_slot] for a ChannelInscribe tx matching channelId,
+    // then queries explorer /blocks/{blockId}?fork=N to get the real explorer TX hash.
+    // slotFrom: lower bound for block scan — pass the slot recorded at inscription time.
+    // Returns {"txHash":"<hex>","blockHash":"<hex>","found":true} or {"found":false,...}
+    Q_INVOKABLE QString findExplorerTxHash(const QString& channelId,
+                                            int slotFrom, int slotTo);
+
+    // Searches finalized blocks [slotFrom, lib_slot] for a tx whose mantle_tx.hash equals txHash.
+    // slotFrom: slot recorded at inscription time — prevents scanning the entire chain.
+    // Returns {"blockHash":"<header.id>","found":true} or {"blockHash":"","found":false}.
+    Q_INVOKABLE QString getBlockForTx(const QString& txHash, int slotFrom = 0);
+
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
     void inscriptionConfirmed(int entryIndex, const QString& inscriptionId,
@@ -106,6 +129,8 @@ signals:
 private:
     void     loadLog();
     void     saveLog();
+    QString  nodeUrl() const;
+    QString  explorerBaseUrl() const;
 
     static QString errorJson(const QString& msg);
     static QString okJson();

--- a/src/plugin/BeaconPlugin.h
+++ b/src/plugin/BeaconPlugin.h
@@ -79,6 +79,9 @@ public:
     // Returns {"ok":true}
     Q_INVOKABLE QString clearSigningKey();
 
+    // Clears the in-memory inscription log and removes inscription-log.json. Returns {"ok":true}.
+    Q_INVOKABLE QString clearInscriptionLog();
+
     // Debug: appends msg to /tmp/beacon_plugin.diag with timestamp. Returns {"ok":true}.
     Q_INVOKABLE QString diagLog(const QString& msg);
 

--- a/src/plugin/BeaconPlugin.h
+++ b/src/plugin/BeaconPlugin.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QVariantList>
 #include <QJsonArray>
+class QNetworkAccessManager;
 
 #include "interface.h"
 
@@ -87,6 +88,13 @@ public:
     // Appends moduleName to manifest-log.json. Returns {"ok":true} or {"error":"..."}.
     Q_INVOKABLE QString recordManifest(const QString& moduleName);
 
+    // Searches recent finalized blocks for a ChannelInscribe tx targeting channelId.
+    // Returns {"txHash":"<hex>"} if found within [slotFrom, slotTo], {"txHash":""} if not.
+    Q_INVOKABLE QString findAnchorTx(const QString& nodeUrl,
+                                     const QString& channelId,
+                                     int slotFrom,
+                                     int slotTo);
+
 signals:
     void eventResponse(const QString& eventName, const QVariantList& data);
     void inscriptionConfirmed(int entryIndex, const QString& inscriptionId,
@@ -103,4 +111,6 @@ private:
     QString     m_signingKeyHex;
     QJsonArray  m_log;             // in-memory inscription log
     QStringList m_watchedSources;  // sources auto-inscribed from stash events
+
+    QNetworkAccessManager* m_nam = nullptr;
 };

--- a/tests/test_beacon_plugin.cpp
+++ b/tests/test_beacon_plugin.cpp
@@ -189,7 +189,7 @@ private slots:
         QCOMPARE(log.size(), 1);
         QCOMPARE(log[0].toObject()["cid"].toString(),
                  QString("QmTestCid1111111111111111111111111111111111111111"));
-        QCOMPARE(log[0].toObject()["status"].toString(), QString("pending"));
+        QCOMPARE(log[0].toObject()["status"].toString(), QString("queued"));
         QCOMPARE(log[0].toObject()["label"].toString(), QString("test label"));
     }
 
@@ -202,8 +202,15 @@ private slots:
         p.initLogos(nullptr);
 
         const QString cid = "QmTestCid1111111111111111111111111111111111111111";
-        p.pinCid(cid, "first");
+        auto first = parseObj(p.pinCid(cid, "first"));
+        int idx = first["entryIndex"].toInt();
 
+        // Confirm with real inscriptionId — marks entry as on-chain
+        p.confirmInscription(idx,
+            "aabbcc1234567890aabbcc1234567890aabbcc1234567890aabbcc1234567890",
+            "confirmed");
+
+        // Second pinCid for same confirmed CID must return duplicate
         auto r = parseObj(p.pinCid(cid, "second attempt"));
         QVERIFY(r["ok"].toBool());
         QVERIFY(r["duplicate"].toBool());
@@ -483,6 +490,156 @@ private slots:
         auto r = parseObj(p.ensureCheckpointsDir());
         QVERIFY(r["ok"].toBool());
         QVERIFY(QDir(tmp.path() + "/checkpoints").exists());
+    }
+    // ── inscription lifecycle: slotFrom / libAtSubmit ────────────────────────
+
+    void testPinCidStoresSlotFrom()
+    {
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto r = parseObj(p.pinCid("QmSlotCid111111111111111111111111111111111111111",
+                                   "label", "keeper", 4711799, 4711345));
+        QVERIFY(r["ok"].toBool());
+        QVERIFY(!r.contains("duplicate"));
+
+        auto log = parseArr(p.getInscriptionLog());
+        QCOMPARE(log.size(), 1);
+        QJsonObject e = log[0].toObject();
+        QCOMPARE(e["slotFrom"].toInt(),    4711799);
+        QCOMPARE(e["libAtSubmit"].toInt(), 4711345);
+        QCOMPARE(e["status"].toString(),   QString("queued"));
+    }
+
+    void testPinCidZeroSlotFromIsValid()
+    {
+        // slotFrom=0 is valid (node info unavailable at time of pinCid)
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto r = parseObj(p.pinCid("QmSlotCid222222222222222222222222222222222222222",
+                                   "label", "keeper", 0, 0));
+        QVERIFY(r["ok"].toBool());
+        auto log = parseArr(p.getInscriptionLog());
+        QCOMPARE(log[0].toObject()["slotFrom"].toInt(), 0);
+    }
+
+    void testConfirmInscriptionNewStatuses()
+    {
+        // Verify all lifecycle statuses persist correctly
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto pin = parseObj(p.pinCid("QmStateCid11111111111111111111111111111111111111", "x"));
+        int idx = pin["entryIndex"].toInt();
+
+        const QStringList states = {"queued","submitted","finalizing","confirmed","failed"};
+        for (const QString& st : states) {
+            QString id = (st == "confirmed") ? "aabbcc1234567890aabbcc1234567890aabbcc1234567890aabbcc1234567890" : "";
+            auto r = parseObj(p.confirmInscription(idx, id, st));
+            QVERIFY2(r["ok"].toBool(), qPrintable("status=" + st));
+            auto log = parseArr(p.getInscriptionLog());
+            QCOMPARE(log[idx].toObject()["status"].toString(), st);
+        }
+    }
+
+    void testGetStatusCountsConfirmedAndOk()
+    {
+        // Both "confirmed" and legacy "ok" count toward inscribedCids
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        auto p1 = parseObj(p.pinCid("QmCountCid1111111111111111111111111111111111111", "a"));
+        auto p2 = parseObj(p.pinCid("QmCountCid2222222222222222222222222222222222222", "b"));
+        auto p3 = parseObj(p.pinCid("QmCountCid3333333333333333333333333333333333333", "c"));
+
+        p.confirmInscription(p1["entryIndex"].toInt(), "aabb1234567890aabb1234567890aabb1234567890aabb1234567890aabb1234", "confirmed");
+        p.confirmInscription(p2["entryIndex"].toInt(), "ccdd1234567890ccdd1234567890ccdd1234567890ccdd1234567890ccdd1234", "ok");
+        p.confirmInscription(p3["entryIndex"].toInt(), "", "failed");
+
+        auto st = parseObj(p.getStatus());
+        QCOMPARE(st["inscribedCids"].toInt(), 2);  // confirmed + ok both count
+        QCOMPARE(st["seenCids"].toInt(), 3);
+    }
+
+    void testGetNodeInfoReturnsErrorOnBadUrl()
+    {
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+        // Point at a definitely-unreachable URL
+        p.setNodeUrl("http://127.0.0.1:19999");
+        auto r = parseObj(p.getNodeInfo());
+        QVERIFY(r.contains("error"));
+        QVERIFY(!r["error"].toString().isEmpty());
+    }
+
+    void testFindExplorerTxHashRejectsEmptyChannelId()
+    {
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+        auto r = parseObj(p.findExplorerTxHash("", 4711799, 4711900));
+        QCOMPARE(r["found"].toBool(), false);
+        QCOMPARE(r["txHash"].toString(), QString());
+    }
+
+    void testFindExplorerTxHashRejectsZeroSlotFrom()
+    {
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+        auto r = parseObj(p.findExplorerTxHash("8edab686b441eac68b194445a5052b65812ed25d68abe582824cadab99d5bf31", 0, 100));
+        QCOMPARE(r["found"].toBool(), false);
+    }
+
+    void testGetBlockForTxReturnsNotFoundForEmptyHash()
+    {
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+        auto r = parseObj(p.getBlockForTx("", 4711799));
+        QCOMPARE(r["found"].toBool(), false);
+        QCOMPARE(r["blockHash"].toString(), QString());
+    }
+
+    void testPinCidLogIncludesAllFields()
+    {
+        // Verify all expected fields are present in log entries
+        QTemporaryDir tmp; QVERIFY(tmp.isValid());
+        BeaconPlugin p;
+        p.setProperty("instancePersistencePath", tmp.path());
+        p.initLogos(nullptr);
+
+        p.pinCid("QmFieldCid11111111111111111111111111111111111111", "my label", "keeper", 1234, 1000);
+        auto log = parseArr(p.getInscriptionLog());
+        QCOMPARE(log.size(), 1);
+        QJsonObject e = log[0].toObject();
+
+        QVERIFY(e.contains("cid"));
+        QVERIFY(e.contains("label"));
+        QVERIFY(e.contains("source"));
+        QVERIFY(e.contains("ts"));
+        QVERIFY(e.contains("status"));
+        QVERIFY(e.contains("inscriptionId"));
+        QVERIFY(e.contains("slotFrom"));
+        QVERIFY(e.contains("libAtSubmit"));
+
+        QCOMPARE(e["slotFrom"].toInt(), 1234);
+        QCOMPARE(e["libAtSubmit"].toInt(), 1000);
+        QCOMPARE(e["source"].toString(), QString("keeper"));
     }
 };
 


### PR DESCRIPTION
## Summary
- Node's `mantle_tx.hash` ≠ explorer hash: sneg node computes Poseidon2 with old `fr_from_bytes` (pre-PR#2481), canonical explorer uses post-fix algorithm
- Fix `findExplorerTxHash` to implement intended 2-step lookup: scan node blocks to find block containing channelId, then query `GET /web/explorer/api/v1/blocks/{blockId}?fork=N` for the real tx hash

## Test plan
- [ ] Preserve item → beacon confirms inscription → copy URL shows working explorer link

🤖 Generated with [Claude Code](https://claude.com/claude-code)